### PR TITLE
feat: onboarding wizard, Zen/Power presets, and microfeatures settings

### DIFF
--- a/app/components/JotsCaptureSheet.vue
+++ b/app/components/JotsCaptureSheet.vue
@@ -50,13 +50,16 @@ async function saveImage() {
     const id = crypto.randomUUID()
     const arrayBuffer = await file.arrayBuffer()
     const blob = new Blob([arrayBuffer], { type: file.type })
-    await store.addImageNote({
-      id,
-      blob,
-      mimeType: file.type,
-      filename: file.name,
-      created_at: new Date().toISOString(),
-    }, url)
+    await store.addImageNote(
+      {
+        id,
+        blob,
+        mimeType: file.type,
+        filename: file.name,
+        created_at: new Date().toISOString(),
+      },
+      url,
+    )
     imagePreview.value = null
     emit('close')
   } catch (err: any) {

--- a/app/components/JotsRecordSheet.vue
+++ b/app/components/JotsRecordSheet.vue
@@ -4,18 +4,37 @@ const emit = defineEmits<{ close: [] }>()
 const store = useJotsStore()
 
 // ─── Speech Recognition types ─────────────────────────────────────────────────
-interface SpeechRecognitionResult { readonly isFinal: boolean; readonly 0: { transcript: string } }
-interface SpeechRecognitionResultList { readonly length: number; [i: number]: SpeechRecognitionResult | undefined }
-interface SpeechRecognitionResultEvent extends Event { readonly resultIndex: number; readonly results: SpeechRecognitionResultList }
-interface SpeechRecognitionErrorEvt extends Event { readonly error: string }
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean
+  readonly 0: { transcript: string }
+}
+interface SpeechRecognitionResultList {
+  readonly length: number
+  [i: number]: SpeechRecognitionResult | undefined
+}
+interface SpeechRecognitionResultEvent extends Event {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+interface SpeechRecognitionErrorEvt extends Event {
+  readonly error: string
+}
 interface SpeechRecognizer extends EventTarget {
-  continuous: boolean; interimResults: boolean; lang: string
+  continuous: boolean
+  interimResults: boolean
+  lang: string
   onresult: ((e: SpeechRecognitionResultEvent) => void) | null
   onend: (() => void) | null
   onerror: ((e: SpeechRecognitionErrorEvt) => void) | null
-  start(): void; stop(): void
+  start(): void
+  stop(): void
 }
-declare global { interface Window { SpeechRecognition: new () => SpeechRecognizer; webkitSpeechRecognition: new () => SpeechRecognizer } }
+declare global {
+  interface Window {
+    SpeechRecognition: new () => SpeechRecognizer
+    webkitSpeechRecognition: new () => SpeechRecognizer
+  }
+}
 
 // ─── Recording state ──────────────────────────────────────────────────────────
 
@@ -37,12 +56,18 @@ async function startRecording() {
     const mimeType = preferred.find((m) => MediaRecorder.isTypeSupported(m)) || ''
     mediaRecorder = new MediaRecorder(stream, { mimeType })
     chunks.length = 0
-    mediaRecorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data) }
-    mediaRecorder.onstop = () => { stream.getTracks().forEach((t) => t.stop()) }
+    mediaRecorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunks.push(e.data)
+    }
+    mediaRecorder.onstop = () => {
+      stream.getTracks().forEach((t) => t.stop())
+    }
     mediaRecorder.start(200)
     isRecording.value = true
     recordDuration.value = 0
-    timerIv = setInterval(() => { recordDuration.value++ }, 1000)
+    timerIv = setInterval(() => {
+      recordDuration.value++
+    }, 1000)
 
     const SRClass = window.SpeechRecognition || window.webkitSpeechRecognition
     if (SRClass) {
@@ -63,7 +88,13 @@ async function startRecording() {
         partialTranscript.value = interimText
       }
       sr.onerror = () => {}
-      sr.onend = () => { if (isRecording.value && sr) { try { sr.start() } catch {} } }
+      sr.onend = () => {
+        if (isRecording.value && sr) {
+          try {
+            sr.start()
+          } catch {}
+        }
+      }
       sr.start()
     }
   } catch (err: any) {
@@ -72,8 +103,16 @@ async function startRecording() {
 }
 
 function stopRecording() {
-  if (timerIv) { clearInterval(timerIv); timerIv = null }
-  if (sr) { try { sr.stop() } catch {} sr = null }
+  if (timerIv) {
+    clearInterval(timerIv)
+    timerIv = null
+  }
+  if (sr) {
+    try {
+      sr.stop()
+    } catch {}
+    sr = null
+  }
   if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop()
   isRecording.value = false
 }
@@ -89,7 +128,13 @@ async function saveRecording() {
     const mimeType = mediaRecorder?.mimeType || 'audio/webm'
     const blob = new Blob(chunks, { type: mimeType })
     const id = crypto.randomUUID()
-    await store.addVoiceNote({ id, blob, mimeType, duration: recordDuration.value, created_at: new Date().toISOString() })
+    await store.addVoiceNote({
+      id,
+      blob,
+      mimeType,
+      duration: recordDuration.value,
+      created_at: new Date().toISOString(),
+    })
 
     const fullTranscript = (liveTranscript.value + partialTranscript.value).trim()
     if (fullTranscript && store.db.isAvailable) {
@@ -139,7 +184,10 @@ function handleClose() {
 
 onUnmounted(() => {
   if (timerIv) clearInterval(timerIv)
-  if (sr) try { sr.stop() } catch {}
+  if (sr)
+    try {
+      sr.stop()
+    } catch {}
   if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop()
 })
 </script>

--- a/app/components/JotsRing.vue
+++ b/app/components/JotsRing.vue
@@ -6,9 +6,7 @@ const props = defineProps<{
   compact?: boolean
 }>()
 
-const emit = defineEmits<{
-  (e: 'select', type: 'text' | 'voice' | 'image'): void
-}>()
+const emit = defineEmits<(e: 'select', type: 'text' | 'voice' | 'image') => void>()
 
 // ─── App settings (reduce-motion awareness) ──────────────────────────────────
 
@@ -116,9 +114,27 @@ const SVG_SIZE = CENTER * 2
 
 // Icon positions at 120° intervals (270° = top, 30° = bottom-right, 150° = bottom-left)
 const nodes = [
-  { type: 'voice' as const, angle: 270, label: 'Voice', icon: 'i-heroicons-microphone', color: 'rose' },
-  { type: 'text' as const, angle: 30, label: 'Scribble', icon: 'i-heroicons-pencil', color: 'amber' },
-  { type: 'image' as const, angle: 150, label: 'Photograph', icon: 'i-heroicons-camera', color: 'sky' },
+  {
+    type: 'voice' as const,
+    angle: 270,
+    label: 'Voice',
+    icon: 'i-heroicons-microphone',
+    color: 'rose',
+  },
+  {
+    type: 'text' as const,
+    angle: 30,
+    label: 'Scribble',
+    icon: 'i-heroicons-pencil',
+    color: 'amber',
+  },
+  {
+    type: 'image' as const,
+    angle: 150,
+    label: 'Photograph',
+    icon: 'i-heroicons-camera',
+    color: 'sky',
+  },
 ]
 
 function nodePos(angleDeg: number) {
@@ -132,9 +148,24 @@ function nodePos(angleDeg: number) {
 // ─── Compact mode icons (fallback for small viewports) ──────────────────────
 
 const compactOptions = [
-  { type: 'voice' as const, label: 'Voice',       icon: 'i-heroicons-microphone', colorClasses: 'bg-rose-500/10 text-rose-400' },
-  { type: 'text' as const,  label: 'Scribble',    icon: 'i-heroicons-pencil',     colorClasses: 'bg-amber-500/10 text-amber-400' },
-  { type: 'image' as const, label: 'Photograph',  icon: 'i-heroicons-camera',     colorClasses: 'bg-sky-500/10 text-sky-400' },
+  {
+    type: 'voice' as const,
+    label: 'Voice',
+    icon: 'i-heroicons-microphone',
+    colorClasses: 'bg-rose-500/10 text-rose-400',
+  },
+  {
+    type: 'text' as const,
+    label: 'Scribble',
+    icon: 'i-heroicons-pencil',
+    colorClasses: 'bg-amber-500/10 text-amber-400',
+  },
+  {
+    type: 'image' as const,
+    label: 'Photograph',
+    icon: 'i-heroicons-camera',
+    colorClasses: 'bg-sky-500/10 text-sky-400',
+  },
 ]
 </script>
 

--- a/app/composables/useJotsStore.ts
+++ b/app/composables/useJotsStore.ts
@@ -116,10 +116,7 @@ export function useJotsStore() {
 
   async function loadAll() {
     if (db.isAvailable) {
-      ;[scribbles.value, todos.value] = await Promise.all([
-        db.getScribbles(),
-        db.getTodos(),
-      ])
+      ;[scribbles.value, todos.value] = await Promise.all([db.getScribbles(), db.getTodos()])
     }
     const storedVoice = await idbGetAll<Omit<VoiceNote, 'url'>>(VOICE_STORE)
     storedVoice.sort((a, b) => b.created_at.localeCompare(a.created_at))
@@ -158,8 +155,12 @@ export function useJotsStore() {
   }
 
   function revokeAllUrls() {
-    voiceNotes.value.forEach((n) => { if (n.url) URL.revokeObjectURL(n.url) })
-    imageNotes.value.forEach((n) => { if (n.url) URL.revokeObjectURL(n.url) })
+    voiceNotes.value.forEach((n) => {
+      if (n.url) URL.revokeObjectURL(n.url)
+    })
+    imageNotes.value.forEach((n) => {
+      if (n.url) URL.revokeObjectURL(n.url)
+    })
   }
 
   return {

--- a/app/composables/useTabReorder.ts
+++ b/app/composables/useTabReorder.ts
@@ -56,9 +56,7 @@ export function useDragReorder<T>(
   function findOverIndex(pos: number): number {
     for (let i = 0; i < itemRects.length; i++) {
       const rect = itemRects[i]!
-      const center = isHorizontal()
-        ? rect.left + rect.width / 2
-        : rect.top + rect.height / 2
+      const center = isHorizontal() ? rect.left + rect.width / 2 : rect.top + rect.height / 2
       if (pos < center) return i
     }
     return itemRects.length - 1
@@ -83,18 +81,14 @@ export function useDragReorder<T>(
         if (i > from && i <= to) {
           const prevRect = itemRects[i - 1]!
           const thisRect = itemRects[i]!
-          shift = isHorizontal()
-            ? prevRect.left - thisRect.left
-            : prevRect.top - thisRect.top
+          shift = isHorizontal() ? prevRect.left - thisRect.left : prevRect.top - thisRect.top
         }
       } else if (from > to) {
         // Dragged item moved backward: items between [to, from) shift forward
         if (i >= to && i < from) {
           const nextRect = itemRects[i + 1]!
           const thisRect = itemRects[i]!
-          shift = isHorizontal()
-            ? nextRect.left - thisRect.left
-            : nextRect.top - thisRect.top
+          shift = isHorizontal() ? nextRect.left - thisRect.left : nextRect.top - thisRect.top
         }
       }
 
@@ -154,7 +148,9 @@ export function useDragReorder<T>(
     }
 
     if (pointerId !== null && containerEl) {
-      try { containerEl.releasePointerCapture(pointerId) } catch {}
+      try {
+        containerEl.releasePointerCapture(pointerId)
+      } catch {}
     }
 
     state.dragging = false
@@ -208,9 +204,11 @@ export function useDragReorder<T>(
     if (!computedBg || computedBg === 'rgba(0, 0, 0, 0)' || computedBg === 'transparent') {
       // Inherit from container or use a fallback
       const containerBg = getComputedStyle(container).backgroundColor
-      floatingEl.style.backgroundColor = containerBg && containerBg !== 'rgba(0, 0, 0, 0)'
-        ? containerBg
-        : getComputedStyle(document.documentElement).getPropertyValue('--ui-bg-muted') || '#1e293b'
+      floatingEl.style.backgroundColor =
+        containerBg && containerBg !== 'rgba(0, 0, 0, 0)'
+          ? containerBg
+          : getComputedStyle(document.documentElement).getPropertyValue('--ui-bg-muted') ||
+            '#1e293b'
     }
 
     document.body.appendChild(floatingEl)
@@ -227,7 +225,9 @@ export function useDragReorder<T>(
     state.dragIndex = index
     state.overIndex = index
 
-    try { containerEl.setPointerCapture(pointerId) } catch {}
+    try {
+      containerEl.setPointerCapture(pointerId)
+    } catch {}
 
     document.addEventListener('pointermove', onPointerMove)
     document.addEventListener('pointerup', onPointerUp)

--- a/app/layouts/blank.vue
+++ b/app/layouts/blank.vue
@@ -1,0 +1,3 @@
+<template>
+  <slot />
+</template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -97,8 +97,6 @@ function navLabel(item: { to: string; label: string }): string {
   return item.label
 }
 
-
-
 const enabledNavItems = computed(() =>
   ALL_NAV_ITEMS.filter((i) => {
     if (i.today && !settings.value.enableToday) return false
@@ -137,7 +135,10 @@ const LONG_PRESS_MS = 500
 const { onPointerDown: navDragPointerDown } = useDragReorder(
   navItems,
   (newOrder) => {
-    setAppSetting('tabOrder', newOrder.map((i) => i.to))
+    setAppSetting(
+      'tabOrder',
+      newOrder.map((i) => i.to),
+    )
   },
   { orientation: 'horizontal' },
 )
@@ -168,12 +169,18 @@ function onNavPointerDown(index: number, e: PointerEvent) {
   const moveThreshold = 10
 
   function detectMove(me: PointerEvent) {
-    if (Math.abs(me.clientX - startX) > moveThreshold || Math.abs(me.clientY - startY) > moveThreshold) {
+    if (
+      Math.abs(me.clientX - startX) > moveThreshold ||
+      Math.abs(me.clientY - startY) > moveThreshold
+    ) {
       cancelLongPress()
     }
   }
   function cancelLongPress() {
-    if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null }
+    if (longPressTimer) {
+      clearTimeout(longPressTimer)
+      longPressTimer = null
+    }
     document.removeEventListener('pointermove', detectMove)
     document.removeEventListener('pointerup', cancelLongPress)
     document.removeEventListener('pointercancel', cancelLongPress)

--- a/app/middleware/onboarding.global.ts
+++ b/app/middleware/onboarding.global.ts
@@ -1,0 +1,15 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if (import.meta.server) return
+  if (to.path === '/onboarding') return
+
+  const onboarded = localStorage.getItem('habitat-onboarded')
+  if (onboarded) return
+
+  // Existing users who already have saved settings — mark onboarded and skip
+  if (localStorage.getItem('habitat-app-settings')) {
+    localStorage.setItem('habitat-onboarded', '1')
+    return
+  }
+
+  return navigateTo('/onboarding')
+})

--- a/app/pages/habits/[id].vue
+++ b/app/pages/habits/[id].vue
@@ -3,6 +3,7 @@ import type { Completion, HabitLog, HabitWithSchedule, Reminder } from '~/types/
 
 const route = useRoute()
 const db = useDatabase()
+const { settings } = useAppSettings()
 const { impact, notification } = useHaptics()
 
 const habit = ref<HabitWithSchedule | null>(null)
@@ -154,6 +155,7 @@ const saving = ref(false)
 const editTagInput = ref('')
 const editAnnotationEntries = ref<{ key: string; value: string }[]>([])
 const editShowAnnotations = ref(false)
+const editShowAdvancedFields = ref(false)
 
 function addEditTag() {
   const tag = editTagInput.value.replace(/,$/, '').trim()
@@ -665,8 +667,8 @@ onMounted(load)
             <UInput v-model="editForm.description" placeholder="Optional description" />
           </UFormField>
 
-          <!-- Tags -->
-          <UFormField label="Tags">
+          <!-- Tags (visible when enabled; otherwise inside Advanced) -->
+          <UFormField v-if="settings.showTagsOnHabits" label="Tags">
             <div class="space-y-2">
               <div v-if="editForm.tags.length" class="flex flex-wrap gap-1">
                 <span
@@ -773,8 +775,8 @@ onMounted(load)
             </div>
           </div>
 
-          <!-- Annotations (collapsible) -->
-          <div>
+          <!-- Annotations (collapsible, visible when enabled; otherwise inside Advanced) -->
+          <div v-if="settings.showAnnotationsOnHabits">
             <button
               class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
               @click="editShowAnnotations = !editShowAnnotations"
@@ -794,6 +796,56 @@ onMounted(load)
               <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addEditAnnotationEntry">
                 <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
               </button>
+            </div>
+          </div>
+
+          <!-- Advanced disclosure: contains fields hidden by microfeature settings -->
+          <div v-if="!settings.showTagsOnHabits || !settings.showAnnotationsOnHabits">
+            <button
+              class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
+              @click="editShowAdvancedFields = !editShowAdvancedFields"
+            >
+              <UIcon :name="editShowAdvancedFields ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+              Advanced
+            </button>
+            <div v-if="editShowAdvancedFields" class="mt-2 space-y-3">
+              <UFormField v-if="!settings.showTagsOnHabits" label="Tags">
+                <div class="space-y-2">
+                  <div v-if="editForm.tags.length" class="flex flex-wrap gap-1">
+                    <span
+                      v-for="tag in editForm.tags"
+                      :key="tag"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-(--ui-bg-elevated) border border-(--ui-border-accented) text-xs text-(--ui-text-toned)"
+                    >
+                      {{ tag }}
+                      <button class="text-(--ui-text-dimmed) hover:text-white leading-none" @click="removeEditTag(tag)">×</button>
+                    </span>
+                  </div>
+                  <UInput v-model="editTagInput" placeholder="Add tag, press Enter" @keydown="onEditTagKeydown" />
+                </div>
+              </UFormField>
+              <div v-if="!settings.showAnnotationsOnHabits">
+                <button
+                  class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
+                  @click="editShowAnnotations = !editShowAnnotations"
+                >
+                  <UIcon :name="editShowAnnotations ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+                  {{ editShowAnnotations ? 'Hide annotations' : editAnnotationEntries.length > 0 ? `Annotations (${editAnnotationEntries.length})` : 'Add annotations' }}
+                </button>
+                <div v-if="editShowAnnotations" class="mt-2 space-y-1.5">
+                  <div v-for="(entry, i) in editAnnotationEntries" :key="i" class="flex items-center gap-1.5">
+                    <UInput v-model="entry.key" placeholder="key" class="w-24 shrink-0" />
+                    <span class="text-slate-600 text-xs">:</span>
+                    <UInput v-model="entry.value" placeholder="value" class="flex-1" />
+                    <button class="text-slate-700 hover:text-red-400 transition-colors" @click="removeEditAnnotationEntry(i)">
+                      <UIcon name="i-heroicons-x-mark" class="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                  <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addEditAnnotationEntry">
+                    <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/app/pages/habits/index.vue
+++ b/app/pages/habits/index.vue
@@ -70,6 +70,7 @@ const form = reactive({
 const tagInput = ref('')
 const annotationEntries = ref<{ key: string; value: string }[]>([])
 const showAnnotations = ref(false)
+const showAdvancedFields = ref(false)
 
 // ── Pending reminders (added before the habit exists in the DB) ─────────────
 const pendingReminders = ref<{ time: string; days: number[] }[]>([])
@@ -214,6 +215,7 @@ function closeModal() {
   tagInput.value = ''
   annotationEntries.value = []
   showAnnotations.value = false
+  showAdvancedFields.value = false
   form.show_due_time = false
   form.due_time = ''
   pendingReminders.value = []
@@ -369,8 +371,8 @@ onMounted(loadHabits)
             <UInput v-model="form.description" placeholder="Optional description" />
           </UFormField>
 
-          <!-- Tags -->
-          <UFormField label="Tags">
+          <!-- Tags (visible when enabled; otherwise inside Advanced) -->
+          <UFormField v-if="settings.showTagsOnHabits" label="Tags">
             <div class="space-y-2">
               <div v-if="form.tags.length" class="flex flex-wrap gap-1">
                 <span
@@ -479,8 +481,8 @@ onMounted(loadHabits)
             </div>
           </div>
 
-          <!-- Annotations (collapsible) -->
-          <div>
+          <!-- Annotations (collapsible, visible when enabled; otherwise inside Advanced) -->
+          <div v-if="settings.showAnnotationsOnHabits">
             <button
               class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
               @click="showAnnotations = !showAnnotations"
@@ -500,6 +502,56 @@ onMounted(loadHabits)
               <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addAnnotationEntry">
                 <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
               </button>
+            </div>
+          </div>
+
+          <!-- Advanced disclosure: contains fields hidden by microfeature settings -->
+          <div v-if="!settings.showTagsOnHabits || !settings.showAnnotationsOnHabits">
+            <button
+              class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
+              @click="showAdvancedFields = !showAdvancedFields"
+            >
+              <UIcon :name="showAdvancedFields ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+              Advanced
+            </button>
+            <div v-if="showAdvancedFields" class="mt-2 space-y-3">
+              <UFormField v-if="!settings.showTagsOnHabits" label="Tags">
+                <div class="space-y-2">
+                  <div v-if="form.tags.length" class="flex flex-wrap gap-1">
+                    <span
+                      v-for="tag in form.tags"
+                      :key="tag"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-(--ui-bg-elevated) border border-(--ui-border-accented) text-xs text-(--ui-text-toned)"
+                    >
+                      {{ tag }}
+                      <button class="text-(--ui-text-dimmed) hover:text-white leading-none" @click="removeTag(tag)">×</button>
+                    </span>
+                  </div>
+                  <UInput v-model="tagInput" placeholder="Add tag, press Enter" @keydown="onTagKeydown" />
+                </div>
+              </UFormField>
+              <div v-if="!settings.showAnnotationsOnHabits">
+                <button
+                  class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
+                  @click="showAnnotations = !showAnnotations"
+                >
+                  <UIcon :name="showAnnotations ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+                  {{ showAnnotations ? 'Hide annotations' : annotationEntries.length > 0 ? `Annotations (${annotationEntries.length})` : 'Add annotations' }}
+                </button>
+                <div v-if="showAnnotations" class="mt-2 space-y-1.5">
+                  <div v-for="(entry, i) in annotationEntries" :key="i" class="flex items-center gap-1.5">
+                    <UInput v-model="entry.key" placeholder="key" class="w-24 shrink-0" />
+                    <span class="text-slate-600 text-xs">:</span>
+                    <UInput v-model="entry.value" placeholder="value" class="flex-1" />
+                    <button class="p-2 -m-1 text-slate-700 hover:text-red-400 transition-colors" @click="removeAnnotationEntry(i)">
+                      <UIcon name="i-heroicons-x-mark" class="w-4 h-4" />
+                    </button>
+                  </div>
+                  <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addAnnotationEntry">
+                    <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/app/pages/jots/edit-[id].vue
+++ b/app/pages/jots/edit-[id].vue
@@ -20,7 +20,9 @@ const newAnnotKey = ref('')
 const newAnnotVal = ref('')
 
 const annotationCount = computed(() => Object.keys(textForm.annotations).length)
-const canSave = computed(() => textForm.title.trim().length > 0 || textForm.content.trim().length > 0)
+const canSave = computed(
+  () => textForm.title.trim().length > 0 || textForm.content.trim().length > 0,
+)
 
 function commitTag() {
   const t = tagInput.value.replace(/,+$/, '').trim()

--- a/app/pages/jots/index.vue
+++ b/app/pages/jots/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { JotItem, VoiceNote, ImageNote } from '~/composables/useJotsStore'
+import type { ImageNote, JotItem, VoiceNote } from '~/composables/useJotsStore'
 
 const router = useRouter()
 const { settings: appSettings } = useAppSettings()
@@ -96,7 +96,9 @@ function togglePlay(note: VoiceNote) {
   let audio = audioMap.get(note.id)
   if (!audio) {
     audio = new Audio(note.url)
-    audio.onended = () => { currentlyPlaying.value = null }
+    audio.onended = () => {
+      currentlyPlaying.value = null
+    }
     audioMap.set(note.id, audio)
   }
   if (currentlyPlaying.value === note.id) {
@@ -110,7 +112,10 @@ function togglePlay(note: VoiceNote) {
 
 async function handleDeleteVoice(note: VoiceNote) {
   const audio = audioMap.get(note.id)
-  if (audio) { audio.pause(); audioMap.delete(note.id) }
+  if (audio) {
+    audio.pause()
+    audioMap.delete(note.id)
+  }
   if (currentlyPlaying.value === note.id) currentlyPlaying.value = null
   await store.deleteVoiceNote(note)
 }

--- a/app/pages/jots/new.vue
+++ b/app/pages/jots/new.vue
@@ -15,7 +15,9 @@ const newAnnotKey = ref('')
 const newAnnotVal = ref('')
 
 const annotationCount = computed(() => Object.keys(textForm.annotations).length)
-const canSave = computed(() => textForm.title.trim().length > 0 || textForm.content.trim().length > 0)
+const canSave = computed(
+  () => textForm.title.trim().length > 0 || textForm.content.trim().length > 0,
+)
 
 function commitTag() {
   const t = tagInput.value.replace(/,+$/, '').trim()

--- a/app/pages/onboarding.vue
+++ b/app/pages/onboarding.vue
@@ -1,0 +1,479 @@
+<script setup lang="ts">
+import { Capacitor } from '@capacitor/core'
+
+definePageMeta({ layout: 'blank' })
+
+const db = useDatabase()
+const { set } = useAppSettings()
+const { requestPermission } = useNotifications()
+const router = useRouter()
+
+// ── Step state ──────────────────────────────────────────────────────────────
+// 0=welcome, 1=tier, 2=zen/power, 3=notifications, 4=first-habit
+const step = ref(0)
+
+function next() {
+  step.value++
+}
+function back() {
+  step.value--
+}
+
+// ── Logo animation ───────────────────────────────────────────────────────────
+const logoAnimating = ref(false)
+onMounted(() => {
+  logoAnimating.value = true
+})
+function onLogoAnimEnd() {
+  logoAnimating.value = false
+}
+function replayLogo() {
+  if (logoAnimating.value) return
+  logoAnimating.value = true
+}
+
+// ── Feature tier ─────────────────────────────────────────────────────────────
+const selectedTier = ref<'simple' | 'standard' | 'everything'>('standard')
+
+const TIERS = [
+  {
+    id: 'simple' as const,
+    icon: 'i-heroicons-list-bullet',
+    title: 'Just habits',
+    description: 'Track daily habits only. Simple and focused.',
+  },
+  {
+    id: 'standard' as const,
+    icon: 'i-heroicons-squares-2x2',
+    title: 'Habits + tasks + notes',
+    description: 'Adds TODOs, check-ins, and Jots for capturing thoughts.',
+    badge: 'Recommended',
+  },
+  {
+    id: 'everything' as const,
+    icon: 'i-heroicons-bolt',
+    title: 'Everything',
+    description: 'Includes timer, oracle suggestions, health tracking, and context filters.',
+  },
+]
+
+function applyTier() {
+  if (selectedTier.value === 'simple') {
+    set('enableJournalling', false)
+    set('enableTodos', false)
+    set('enableBored', false)
+    set('enableTimer', false)
+    set('enableHealth', false)
+    set('enableContextFilter', false)
+  } else if (selectedTier.value === 'everything') {
+    set('enableJournalling', true)
+    set('enableTodos', true)
+    set('enableBored', true)
+    set('enableTimer', true)
+    set('enableHealth', true)
+    set('enableContextFilter', true)
+  }
+  // 'standard' keeps defaults (enableJournalling+enableTodos true, rest false)
+}
+
+// ── Display presence (Zen / Power) ───────────────────────────────────────────
+const selectedPresence = ref<'zen' | 'power'>('zen')
+
+const PRESENCES = [
+  {
+    id: 'zen' as const,
+    icon: 'i-heroicons-moon',
+    title: 'Zen',
+    description: 'Clean and distraction-free. Just your habits, front and centre.',
+  },
+  {
+    id: 'power' as const,
+    icon: 'i-heroicons-adjustments-horizontal',
+    title: 'Power',
+    description: 'For the detail-oriented. Labels, notes, and context filtering.',
+  },
+]
+
+function applyPresence() {
+  const on = selectedPresence.value === 'power'
+  set('showTagsOnToday', on)
+  set('showTagsOnHabits', on)
+  set('showAnnotationsOnToday', on)
+  set('showAnnotationsOnHabits', on)
+}
+
+// ── Notifications ─────────────────────────────────────────────────────────────
+const requestingNotif = ref(false)
+const isNative = Capacitor.isNativePlatform()
+
+async function handleEnableNotifications() {
+  requestingNotif.value = true
+  try {
+    await requestPermission()
+  } finally {
+    requestingNotif.value = false
+    next()
+  }
+}
+
+// ── First habit ───────────────────────────────────────────────────────────────
+const habitName = ref('')
+const habitSchedule = ref<'daily' | 'weekdays'>('daily')
+const habitIcon = ref('i-heroicons-star')
+const savingHabit = ref(false)
+
+const HABIT_ICONS = [
+  { name: 'i-heroicons-sun', label: 'Morning' },
+  { name: 'i-heroicons-fire', label: 'Fitness' },
+  { name: 'i-heroicons-book-open', label: 'Reading' },
+  { name: 'i-heroicons-heart', label: 'Health' },
+  { name: 'i-heroicons-sparkles', label: 'Mindfulness' },
+  { name: 'i-heroicons-pencil', label: 'Writing' },
+  { name: 'i-heroicons-musical-note', label: 'Music' },
+  { name: 'i-heroicons-moon', label: 'Sleep' },
+  { name: 'i-heroicons-beaker', label: 'Hydration' },
+  { name: 'i-heroicons-star', label: 'Goal' },
+]
+
+async function completeOnboarding(skip: boolean) {
+  applyTier()
+  applyPresence()
+  localStorage.setItem('habitat-onboarded', '1')
+  localStorage.setItem('habitat-permissions-onboarded', '1')
+
+  if (!skip && habitName.value.trim() && db.isAvailable) {
+    savingHabit.value = true
+    try {
+      const newHabit = await db.createHabit({
+        name: habitName.value.trim(),
+        description: '',
+        color: '#06b6d4',
+        icon: habitIcon.value,
+        frequency: 'daily',
+        tags: [],
+        annotations: {},
+        type: 'BOOLEAN',
+        target_value: 1,
+        paused_until: null,
+      })
+      if (habitSchedule.value === 'weekdays' && newHabit.schedule) {
+        await db.updateHabitSchedule({
+          id: newHabit.schedule.id,
+          schedule_type: 'SPECIFIC_DAYS',
+          days_of_week: [1, 2, 3, 4, 5],
+        })
+      }
+    } catch (err) {
+      console.error('[Onboarding] Failed to create habit:', err)
+    } finally {
+      savingHabit.value = false
+    }
+  }
+
+  router.replace('/')
+}
+</script>
+
+<template>
+  <div class="min-h-dvh bg-(--ui-bg) text-(--ui-text) flex flex-col">
+    <!-- Content area -->
+    <div class="flex-1 flex flex-col items-center justify-center px-6 pt-safe-top">
+      <div class="w-full max-w-sm">
+
+        <!-- STEP 0: Welcome -->
+        <Transition name="step" mode="out-in">
+          <div v-if="step === 0" key="welcome" class="flex flex-col items-center text-center gap-6">
+            <svg
+              class="plant-logo-lg text-primary-400 w-16 h-[4.4rem]"
+              :class="{ 'sprout-anim': logoAnimating }"
+              viewBox="0 0 40 44"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              role="img"
+              aria-label="Habitat"
+              @click="replayLogo"
+              @animationend="onLogoAnimEnd"
+            >
+              <line class="sprout-stem" x1="20" y1="40" x2="20" y2="24" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" pathLength="1" />
+              <path class="sprout-leaf-l" d="M 20,24 C 11,23 4,29 8,34 C 11,37 19,30 20,24" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" pathLength="1" />
+              <path class="sprout-branch-r" d="M 20,24 C 26,20 32,14 30,8 C 28,5 20,13 20,24" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" pathLength="1" />
+              <path class="sprout-soil" d="M 8,40 C 12,37 28,37 32,40" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="round" pathLength="1" />
+            </svg>
+
+            <div class="space-y-2">
+              <h1 class="text-3xl font-bold tracking-tight">Welcome to Habitat</h1>
+              <p class="text-(--ui-text-muted) text-base leading-relaxed">
+                Private habit tracking. All your data stays on your device, always.
+              </p>
+            </div>
+
+            <UButton size="lg" class="w-full mt-2" @click="next">
+              Get started
+              <template #trailing>
+                <UIcon name="i-heroicons-arrow-right" class="w-4 h-4" />
+              </template>
+            </UButton>
+          </div>
+        </Transition>
+
+        <!-- STEP 1: Feature tier -->
+        <Transition name="step" mode="out-in">
+          <div v-if="step === 1" key="features" class="flex flex-col gap-5">
+            <div class="space-y-1">
+              <h2 class="text-2xl font-bold tracking-tight">How do you want to use it?</h2>
+              <p class="text-sm text-(--ui-text-muted)">You can change this any time in Settings.</p>
+            </div>
+
+            <div class="flex flex-col gap-3">
+              <button
+                v-for="tier in TIERS"
+                :key="tier.id"
+                class="flex items-start gap-4 p-4 rounded-xl border text-left transition-colors"
+                :class="selectedTier === tier.id
+                  ? 'border-primary-500 bg-primary-500/10'
+                  : 'border-(--ui-border) bg-(--ui-bg-elevated) hover:border-(--ui-border-accented)'"
+                @click="selectedTier = tier.id"
+              >
+                <div
+                  class="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
+                  :class="selectedTier === tier.id ? 'bg-primary-500/20' : 'bg-(--ui-bg-muted)'"
+                >
+                  <UIcon :name="tier.icon" class="w-5 h-5" :class="selectedTier === tier.id ? 'text-primary-400' : 'text-(--ui-text-muted)'" />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="font-semibold text-sm">{{ tier.title }}</span>
+                    <span
+                      v-if="tier.badge"
+                      class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-primary-500/20 text-primary-400 leading-tight"
+                    >
+                      {{ tier.badge }}
+                    </span>
+                  </div>
+                  <p class="text-xs text-(--ui-text-muted) mt-0.5 leading-relaxed">{{ tier.description }}</p>
+                </div>
+                <div class="shrink-0 mt-1">
+                  <div
+                    class="w-4 h-4 rounded-full border-2 flex items-center justify-center"
+                    :class="selectedTier === tier.id ? 'border-primary-500 bg-primary-500' : 'border-(--ui-border-accented)'"
+                  >
+                    <div v-if="selectedTier === tier.id" class="w-1.5 h-1.5 rounded-full bg-white" />
+                  </div>
+                </div>
+              </button>
+            </div>
+
+            <div class="flex gap-3">
+              <UButton variant="ghost" color="neutral" @click="back">
+                <UIcon name="i-heroicons-arrow-left" class="w-4 h-4" />
+                Back
+              </UButton>
+              <UButton class="flex-1" @click="next">Next</UButton>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- STEP 2: Zen / Power display preset -->
+        <Transition name="step" mode="out-in">
+          <div v-if="step === 2" key="presence" class="flex flex-col gap-5">
+            <div class="space-y-1">
+              <h2 class="text-2xl font-bold tracking-tight">How should it look?</h2>
+              <p class="text-sm text-(--ui-text-muted)">Tags, labels, and annotations can always be toggled later in Settings.</p>
+            </div>
+
+            <div class="flex flex-col gap-3">
+              <button
+                v-for="p in PRESENCES"
+                :key="p.id"
+                class="flex items-start gap-4 p-4 rounded-xl border text-left transition-colors"
+                :class="selectedPresence === p.id
+                  ? 'border-primary-500 bg-primary-500/10'
+                  : 'border-(--ui-border) bg-(--ui-bg-elevated) hover:border-(--ui-border-accented)'"
+                @click="selectedPresence = p.id"
+              >
+                <div
+                  class="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
+                  :class="selectedPresence === p.id ? 'bg-primary-500/20' : 'bg-(--ui-bg-muted)'"
+                >
+                  <UIcon :name="p.icon" class="w-5 h-5" :class="selectedPresence === p.id ? 'text-primary-400' : 'text-(--ui-text-muted)'" />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <span class="font-semibold text-sm">{{ p.title }}</span>
+                  <p class="text-xs text-(--ui-text-muted) mt-0.5 leading-relaxed">{{ p.description }}</p>
+                </div>
+                <div class="shrink-0 mt-1">
+                  <div
+                    class="w-4 h-4 rounded-full border-2 flex items-center justify-center"
+                    :class="selectedPresence === p.id ? 'border-primary-500 bg-primary-500' : 'border-(--ui-border-accented)'"
+                  >
+                    <div v-if="selectedPresence === p.id" class="w-1.5 h-1.5 rounded-full bg-white" />
+                  </div>
+                </div>
+              </button>
+            </div>
+
+            <div class="flex gap-3">
+              <UButton variant="ghost" color="neutral" @click="back">
+                <UIcon name="i-heroicons-arrow-left" class="w-4 h-4" />
+                Back
+              </UButton>
+              <UButton class="flex-1" @click="next">Next</UButton>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- STEP 3: Notifications -->
+        <Transition name="step" mode="out-in">
+          <div v-if="step === 3" key="notifications" class="flex flex-col items-center text-center gap-6">
+            <div class="w-20 h-20 rounded-2xl bg-primary-500/15 flex items-center justify-center">
+              <UIcon name="i-heroicons-bell" class="w-10 h-10 text-primary-400" />
+            </div>
+
+            <div class="space-y-2">
+              <h2 class="text-2xl font-bold tracking-tight">Get reminded to check in</h2>
+              <p class="text-(--ui-text-muted) text-sm leading-relaxed">
+                Enable notifications so Habitat can remind you of habits and tasks at the right time.
+                <span v-if="isNative"> On Android, you can also grant exact alarm and battery exemption permissions.</span>
+              </p>
+            </div>
+
+            <div class="w-full space-y-3">
+              <UButton
+                class="w-full"
+                :loading="requestingNotif"
+                @click="handleEnableNotifications"
+              >
+                <UIcon name="i-heroicons-bell" class="w-4 h-4" />
+                Enable notifications
+              </UButton>
+              <UButton variant="ghost" color="neutral" class="w-full" @click="next">
+                Skip for now
+              </UButton>
+            </div>
+
+            <UButton variant="ghost" color="neutral" size="sm" class="self-start -ml-1" @click="back">
+              <UIcon name="i-heroicons-arrow-left" class="w-4 h-4" />
+              Back
+            </UButton>
+          </div>
+        </Transition>
+
+        <!-- STEP 4: First habit -->
+        <Transition name="step" mode="out-in">
+          <div v-if="step === 4" key="habit" class="flex flex-col gap-5">
+            <div class="space-y-1">
+              <h2 class="text-2xl font-bold tracking-tight">Create your first habit</h2>
+              <p class="text-sm text-(--ui-text-muted)">You can always add more later.</p>
+            </div>
+
+            <!-- Name -->
+            <div class="space-y-1.5">
+              <label class="text-sm font-medium text-(--ui-text-muted)">Name</label>
+              <UInput
+                v-model="habitName"
+                placeholder="e.g. Morning walk"
+                size="lg"
+                autofocus
+              />
+            </div>
+
+            <!-- Schedule -->
+            <div class="space-y-1.5">
+              <label class="text-sm font-medium text-(--ui-text-muted)">Schedule</label>
+              <div class="flex gap-2">
+                <button
+                  class="flex-1 py-2 px-3 rounded-lg border text-sm font-medium transition-colors"
+                  :class="habitSchedule === 'daily'
+                    ? 'border-primary-500 bg-primary-500/10 text-primary-400'
+                    : 'border-(--ui-border) bg-(--ui-bg-elevated) text-(--ui-text-muted) hover:border-(--ui-border-accented)'"
+                  @click="habitSchedule = 'daily'"
+                >
+                  Every day
+                </button>
+                <button
+                  class="flex-1 py-2 px-3 rounded-lg border text-sm font-medium transition-colors"
+                  :class="habitSchedule === 'weekdays'
+                    ? 'border-primary-500 bg-primary-500/10 text-primary-400'
+                    : 'border-(--ui-border) bg-(--ui-bg-elevated) text-(--ui-text-muted) hover:border-(--ui-border-accented)'"
+                  @click="habitSchedule = 'weekdays'"
+                >
+                  Weekdays
+                </button>
+              </div>
+            </div>
+
+            <!-- Icon picker -->
+            <div class="space-y-1.5">
+              <label class="text-sm font-medium text-(--ui-text-muted)">Icon</label>
+              <div class="grid grid-cols-5 gap-2">
+                <button
+                  v-for="ic in HABIT_ICONS"
+                  :key="ic.name"
+                  class="flex flex-col items-center gap-1 p-2 rounded-lg border text-xs transition-colors"
+                  :class="habitIcon === ic.name
+                    ? 'border-primary-500 bg-primary-500/10'
+                    : 'border-(--ui-border) bg-(--ui-bg-elevated) hover:border-(--ui-border-accented)'"
+                  :title="ic.label"
+                  @click="habitIcon = ic.name"
+                >
+                  <UIcon :name="ic.name" class="w-5 h-5" :class="habitIcon === ic.name ? 'text-primary-400' : 'text-(--ui-text-muted)'" />
+                  <span class="text-[10px] text-(--ui-text-dimmed) leading-none">{{ ic.label }}</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-3 pt-1">
+              <UButton variant="ghost" color="neutral" @click="back">
+                <UIcon name="i-heroicons-arrow-left" class="w-4 h-4" />
+                Back
+              </UButton>
+              <UButton
+                class="flex-1"
+                :loading="savingHabit"
+                :disabled="!habitName.trim()"
+                @click="completeOnboarding(false)"
+              >
+                Start Habitat
+              </UButton>
+            </div>
+
+            <button
+              class="text-sm text-(--ui-text-dimmed) hover:text-(--ui-text-muted) transition-colors text-center"
+              @click="completeOnboarding(true)"
+            >
+              Skip — I'll do this later
+            </button>
+          </div>
+        </Transition>
+      </div>
+    </div>
+
+    <!-- Progress dots (5 total) -->
+    <div class="pb-safe-bottom flex justify-center gap-2 py-6">
+      <div
+        v-for="i in 5"
+        :key="i"
+        class="rounded-full transition-all duration-300"
+        :class="step === i - 1
+          ? 'w-6 h-2 bg-primary-500'
+          : 'w-2 h-2 bg-(--ui-border-accented)'"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.step-enter-active,
+.step-leave-active {
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+.step-enter-from {
+  opacity: 0;
+  transform: translateX(16px);
+}
+.step-leave-to {
+  opacity: 0;
+  transform: translateX(-16px);
+}
+</style>

--- a/app/pages/settings/display.vue
+++ b/app/pages/settings/display.vue
@@ -21,8 +21,6 @@ function setTheme(theme: AppTheme) {
 
 // ── Tab order ───────────────────────────────────────────────────────────────
 
-
-
 function isNavEnabled(item: NavItem): boolean {
   if (item.today && !appSettings.value.enableToday) return false
   if (item.health && !appSettings.value.enableHealth) return false
@@ -53,7 +51,10 @@ const tabOrderContainerRef = ref<HTMLElement | null>(null)
 const { onPointerDown } = useDragReorder(
   orderedNavItems,
   (newOrder) => {
-    setAppSetting('tabOrder', newOrder.map((i) => i.to))
+    setAppSetting(
+      'tabOrder',
+      newOrder.map((i) => i.to),
+    )
   },
   { orientation: 'vertical' },
 )
@@ -62,6 +63,29 @@ const hasCustomOrder = computed(() => appSettings.value.tabOrder.length > 0)
 
 function resetTabOrder() {
   setAppSetting('tabOrder', [])
+}
+
+// ── Microfeatures ────────────────────────────────────────────────────────────
+const anyMicrofeatureOn = computed(
+  () =>
+    appSettings.value.showTagsOnHabits ||
+    appSettings.value.showAnnotationsOnHabits ||
+    appSettings.value.enableContextFilter,
+)
+
+const microExpanded = ref(false)
+onMounted(() => {
+  microExpanded.value = anyMicrofeatureOn.value
+})
+
+function setTags(val: boolean) {
+  setAppSetting('showTagsOnToday', val)
+  setAppSetting('showTagsOnHabits', val)
+}
+
+function setAnnotations(val: boolean) {
+  setAppSetting('showAnnotationsOnToday', val)
+  setAppSetting('showAnnotationsOnHabits', val)
 }
 </script>
 
@@ -265,59 +289,58 @@ function resetTabOrder() {
     </section>
 
     <section class="space-y-2">
-      <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed) px-1">Habits page</p>
+      <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed) px-1">Microfeatures</p>
       <UCard :ui="{ root: 'rounded-2xl', body: 'p-0 sm:p-0 divide-y divide-slate-800' }">
 
-        <div class="flex items-center justify-between px-4 py-3">
-          <div class="space-y-0.5">
-            <p class="text-sm font-medium">Show tags</p>
-            <p class="text-xs text-(--ui-text-dimmed)">Display habit tags in the habits list.</p>
-          </div>
-          <USwitch
-            :model-value="appSettings.showTagsOnHabits"
-            @update:model-value="setAppSetting('showTagsOnHabits', $event)"
+        <!-- Collapsible header -->
+        <button
+          class="flex items-center justify-between w-full px-4 py-3 text-left"
+          @click="microExpanded = !microExpanded"
+        >
+          <span class="text-sm font-medium">Advanced display options</span>
+          <UIcon
+            :name="microExpanded ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'"
+            class="w-4 h-4 text-(--ui-text-muted) transition-transform"
           />
-        </div>
+        </button>
 
-        <div class="flex items-center justify-between px-4 py-3">
-          <div class="space-y-0.5">
-            <p class="text-sm font-medium">Show annotations</p>
-            <p class="text-xs text-(--ui-text-dimmed)">Display key:value metadata in the habits list.</p>
+        <template v-if="microExpanded">
+          <!-- Show tags (today + habits) -->
+          <div class="flex items-center justify-between px-4 py-3.5">
+            <div class="space-y-0.5">
+              <p class="text-sm font-medium">Show tags</p>
+              <p class="text-xs text-(--ui-text-dimmed)">Display habit tags on the Today view and in the habits list.</p>
+            </div>
+            <USwitch
+              :model-value="appSettings.showTagsOnHabits"
+              @update:model-value="setTags($event)"
+            />
           </div>
-          <USwitch
-            :model-value="appSettings.showAnnotationsOnHabits"
-            @update:model-value="setAppSetting('showAnnotationsOnHabits', $event)"
-          />
-        </div>
 
-      </UCard>
-    </section>
-
-    <section class="space-y-2">
-      <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed) px-1">Today page</p>
-      <UCard :ui="{ root: 'rounded-2xl', body: 'p-0 sm:p-0 divide-y divide-slate-800' }">
-
-        <div class="flex items-center justify-between px-4 py-3">
-          <div class="space-y-0.5">
-            <p class="text-sm font-medium">Show tags</p>
-            <p class="text-xs text-(--ui-text-dimmed)">Display habit tags in today's list.</p>
+          <!-- Show annotations (today + habits) -->
+          <div class="flex items-center justify-between px-4 py-3.5">
+            <div class="space-y-0.5">
+              <p class="text-sm font-medium">Show annotations</p>
+              <p class="text-xs text-(--ui-text-dimmed)">Display key:value metadata on the Today view and in the habits list.</p>
+            </div>
+            <USwitch
+              :model-value="appSettings.showAnnotationsOnHabits"
+              @update:model-value="setAnnotations($event)"
+            />
           </div>
-          <USwitch
-            :model-value="appSettings.showTagsOnToday"
-            @update:model-value="setAppSetting('showTagsOnToday', $event)"
-          />
-        </div>
 
-        <div class="flex items-center justify-between px-4 py-3">
-          <div class="space-y-0.5">
-            <p class="text-sm font-medium">Show annotations</p>
-            <p class="text-xs text-(--ui-text-dimmed)">Display key:value metadata in today's list.</p>
+          <!-- Context filter -->
+          <div class="flex items-center justify-between px-4 py-3.5">
+            <div class="space-y-0.5">
+              <p class="text-sm font-medium">Context filter</p>
+              <p class="text-xs text-(--ui-text-dimmed)">Show a tag filter strip in the header to focus on specific contexts.</p>
+            </div>
+            <USwitch
+              :model-value="appSettings.enableContextFilter"
+              @update:model-value="setAppSetting('enableContextFilter', $event)"
+            />
           </div>
-          <USwitch
-            :model-value="appSettings.showAnnotationsOnToday"
-            @update:model-value="setAppSetting('showAnnotationsOnToday', $event)"
-          />
-        </div>
+        </template>
 
       </UCard>
     </section>


### PR DESCRIPTION
## Summary

- **5-step onboarding wizard** shown on first launch (skipped for existing users with saved settings)
  - Welcome screen with animated sprout logo
  - Feature tier picker: Just habits / Habits + tasks + notes / Everything
  - **Zen vs Power preset**: Zen hides tags/annotations for a clean experience; Power enables them for detail-oriented users
  - Notifications permission request
  - First habit creation with icon picker and schedule selector
- **Microfeatures section** in Settings → Display replaces the old per-page "Habits page" / "Today page" sections
  - Collapsible card (auto-expands if any microfeature is on)
  - "Show tags" and "Show annotations" each set both Today + Habits views with a single toggle
  - Context filter toggle moved here
- **Habit create/edit forms**: tags and annotations collapse into a silent "Advanced" disclosure row when their respective settings are off — data is always preserved

## Test plan

- [ ] Fresh install (no `habitat-onboarded` in localStorage) → onboarding wizard appears
- [ ] Existing user with saved settings → wizard is skipped, lands on home
- [ ] Zen preset → all `showTags*` / `showAnnotations*` flags set to false
- [ ] Power preset → all four flags set to true
- [ ] Settings → Display → Microfeatures section collapsed when all off, expanded when any on
- [ ] "Show tags" toggle updates both today and habits views simultaneously
- [ ] Habit create form: tags/annotations hidden in main form when settings off, visible inside "Advanced"
- [ ] Habit edit form: same behaviour as create
- [ ] Completing onboarding without creating a habit routes to home correctly
- [ ] Notification permission flow works on web and native

🤖 Generated with [Claude Code](https://claude.com/claude-code)