### PR TITLE
Consolidate icon usage into centralized registry

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -105,21 +105,21 @@ function dismissPermissionModal() {
 
           <div class="space-y-3">
             <div class="flex gap-3 items-start">
-              <UIcon name="i-heroicons-bell" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
+              <AppIcon name="bell" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
               <div>
                 <p class="text-sm font-medium">Notifications</p>
                 <p class="text-xs text-(--ui-text-dimmed)">Show reminders for your habits and check-ins.</p>
               </div>
             </div>
             <div class="flex gap-3 items-start">
-              <UIcon name="i-heroicons-clock" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
+              <AppIcon name="clock" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
               <div>
                 <p class="text-sm font-medium">Exact alarms</p>
                 <p class="text-xs text-(--ui-text-dimmed)">Fire reminders at the exact time you scheduled them.</p>
               </div>
             </div>
             <div class="flex gap-3 items-start">
-              <UIcon name="i-heroicons-battery-100" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
+              <AppIcon name="battery-100" class="w-5 h-5 text-primary-400 mt-0.5 shrink-0" />
               <div>
                 <p class="text-sm font-medium">Battery optimization exemption</p>
                 <p class="text-xs text-(--ui-text-dimmed)">Keep reminders working when the app is in the background.</p>

--- a/app/components/AppIcon.vue
+++ b/app/components/AppIcon.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { type IconVariant, resolveIcon } from '~/utils/icons'
+
+const props = withDefaults(
+  defineProps<{
+    /** Registry name (e.g., 'star') or raw icon class (e.g., 'i-heroicons-star') */
+    name: string
+    /** Icon variant: outline (default), solid, or micro */
+    variant?: IconVariant
+    /** Dynamic color — applied as inline style */
+    color?: string
+  }>(),
+  { variant: 'outline' },
+)
+
+const resolved = computed(() => resolveIcon(props.name, props.variant))
+const colorStyle = computed(() => (props.color ? { color: props.color } : undefined))
+</script>
+
+<template>
+  <UIcon :name="resolved" :style="colorStyle" />
+</template>

--- a/app/components/BackNav.vue
+++ b/app/components/BackNav.vue
@@ -8,7 +8,7 @@ defineProps<{
 <template>
   <div class="flex items-center gap-2 -mb-1">
     <UButton
-      icon="i-heroicons-arrow-left"
+      :icon="resolveIcon('arrow-left')"
       variant="ghost"
       color="neutral"
       size="sm"

--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -23,8 +23,8 @@ function toggle() {
       class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1.5 transition-colors"
       @click="toggle"
     >
-      <UIcon
-        :name="open ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+      <AppIcon
+        :name="open ? 'chevron-down' : 'chevron-right'"
         class="w-3.5 h-3.5"
       />
       {{ buttonLabel }}

--- a/app/components/ConfirmDialog.vue
+++ b/app/components/ConfirmDialog.vue
@@ -52,7 +52,7 @@ const iconText = computed(() => {
             class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
             :class="iconBg"
           >
-            <UIcon :name="icon" class="w-5 h-5" :class="iconText" />
+            <AppIcon :name="icon" class="w-5 h-5" :class="iconText" />
           </div>
           <div class="space-y-1">
             <p class="font-semibold">{{ title }}</p>

--- a/app/components/EmptyState.vue
+++ b/app/components/EmptyState.vue
@@ -9,7 +9,7 @@ defineProps<{
 <template>
   <section class="flex flex-col items-center justify-center gap-4 py-12 text-center">
     <div class="w-16 h-16 rounded-full bg-(--ui-bg-elevated) flex items-center justify-center">
-      <UIcon :name="icon" class="w-8 h-8 text-(--ui-text-muted)" />
+      <AppIcon :name="icon" class="w-8 h-8 text-(--ui-text-muted)" />
     </div>
     <div class="space-y-1">
       <p class="font-semibold text-(--ui-text)">{{ title }}</p>

--- a/app/components/JotsCaptureSheet.vue
+++ b/app/components/JotsCaptureSheet.vue
@@ -82,10 +82,10 @@ onUnmounted(() => {
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
-        <UButton v-if="imagePreview" icon="i-heroicons-arrow-left" variant="ghost" color="neutral" size="sm" @click="cancelPreview" />
+        <UButton v-if="imagePreview" :icon="resolveIcon('arrow-left')" variant="ghost" color="neutral" size="sm" @click="cancelPreview" />
         <h3 class="text-base font-semibold">Photograph</h3>
       </div>
-      <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="emit('close')" />
+      <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="emit('close')" />
     </div>
 
     <UAlert
@@ -93,19 +93,19 @@ onUnmounted(() => {
       :title="errorMsg"
       color="error"
       variant="soft"
-      icon="i-heroicons-exclamation-circle"
-      :close-button="{ icon: 'i-heroicons-x-mark', color: 'error', variant: 'ghost', size: 'sm' }"
+      :icon="resolveIcon('exclamation-circle')"
+      :close-button="{ icon: resolveIcon('x-mark'), color: 'error', variant: 'ghost', size: 'sm' }"
       @close="errorMsg = null"
     />
 
     <div v-if="!imagePreview" class="flex flex-col items-center gap-5 py-4">
       <div class="w-20 h-20 rounded-2xl bg-(--ui-bg-elevated) border border-(--ui-border-accented) flex items-center justify-center">
-        <UIcon name="i-heroicons-photo" class="w-10 h-10 text-(--ui-text-dimmed)" />
+        <AppIcon name="photo" class="w-10 h-10 text-(--ui-text-dimmed)" />
       </div>
       <p class="text-xs text-(--ui-text-dimmed)">Choose an image source</p>
       <div class="flex gap-3">
-        <UButton icon="i-heroicons-photo" variant="soft" color="neutral" @click="pickFromGallery">Gallery</UButton>
-        <UButton icon="i-heroicons-camera" variant="soft" color="neutral" @click="pickFromCamera">Camera</UButton>
+        <UButton :icon="resolveIcon('photo')" variant="soft" color="neutral" @click="pickFromGallery">Gallery</UButton>
+        <UButton :icon="resolveIcon('camera')" variant="soft" color="neutral" @click="pickFromCamera">Camera</UButton>
       </div>
     </div>
 

--- a/app/components/JotsRecordSheet.vue
+++ b/app/components/JotsRecordSheet.vue
@@ -201,7 +201,7 @@ onUnmounted(() => {
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <h3 class="text-base font-semibold">Voice Recording</h3>
-      <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" :disabled="isRecording" @click="handleClose" />
+      <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" :disabled="isRecording" @click="handleClose" />
     </div>
 
     <UAlert
@@ -209,8 +209,8 @@ onUnmounted(() => {
       :title="errorMsg"
       color="error"
       variant="soft"
-      icon="i-heroicons-exclamation-circle"
-      :close-button="{ icon: 'i-heroicons-x-mark', color: 'error', variant: 'ghost', size: 'sm' }"
+      :icon="resolveIcon('exclamation-circle')"
+      :close-button="{ icon: resolveIcon('x-mark'), color: 'error', variant: 'ghost', size: 'sm' }"
       @close="errorMsg = null"
     />
 
@@ -226,8 +226,8 @@ onUnmounted(() => {
           : 'bg-(--ui-bg-elevated) border-2 border-(--ui-border-accented) hover:border-primary-500'"
         @click="isRecording ? stopRecording() : startRecording()"
       >
-        <UIcon
-          :name="isRecording ? 'i-heroicons-stop' : 'i-heroicons-microphone'"
+        <AppIcon
+          :name="isRecording ? 'stop' : 'microphone'"
           class="w-8 h-8"
           :class="isRecording ? 'text-red-400' : 'text-rose-400'"
         />

--- a/app/components/JotsRing.vue
+++ b/app/components/JotsRing.vue
@@ -121,21 +121,21 @@ const nodes = [
     type: 'voice' as const,
     angle: 270,
     label: 'Voice',
-    icon: 'i-heroicons-microphone',
+    icon: resolveIcon('microphone'),
     color: 'rose',
   },
   {
     type: 'text' as const,
     angle: 30,
     label: 'Scribble',
-    icon: 'i-heroicons-pencil',
+    icon: resolveIcon('pencil'),
     color: 'amber',
   },
   {
     type: 'image' as const,
     angle: 150,
     label: 'Photograph',
-    icon: 'i-heroicons-camera',
+    icon: resolveIcon('camera'),
     color: 'sky',
   },
 ]
@@ -154,19 +154,19 @@ const compactOptions = [
   {
     type: 'voice' as const,
     label: 'Voice',
-    icon: 'i-heroicons-microphone',
+    icon: resolveIcon('microphone'),
     colorClasses: 'bg-rose-500/10 text-rose-400',
   },
   {
     type: 'text' as const,
     label: 'Scribble',
-    icon: 'i-heroicons-pencil',
+    icon: resolveIcon('pencil'),
     colorClasses: 'bg-amber-500/10 text-amber-400',
   },
   {
     type: 'image' as const,
     label: 'Photograph',
-    icon: 'i-heroicons-camera',
+    icon: resolveIcon('camera'),
     colorClasses: 'bg-sky-500/10 text-sky-400',
   },
 ]
@@ -184,7 +184,7 @@ const compactOptions = [
         @click="emit('select', opt.type)"
       >
         <div class="w-10 h-10 rounded-full flex items-center justify-center" :class="opt.colorClasses">
-          <UIcon :name="opt.icon" class="w-5 h-5" />
+          <AppIcon :name="opt.icon" class="w-5 h-5" />
         </div>
         <span class="text-xs text-(--ui-text-toned)">{{ opt.label }}</span>
       </button>
@@ -282,7 +282,7 @@ const compactOptions = [
             'bg-sky-500/15 border-sky-500/40 hover:border-sky-400 hover:bg-sky-500/25': node.color === 'sky',
           }"
         >
-          <UIcon
+          <AppIcon
             :name="node.icon"
             class="w-5 h-5"
             :class="{

--- a/app/components/LogSheet.vue
+++ b/app/components/LogSheet.vue
@@ -156,7 +156,7 @@ const targetFormatted = computed(() => {
               class="w-11 h-11 rounded-2xl flex-shrink-0 flex items-center justify-center"
               :style="{ backgroundColor: iconColor + '18', border: `1px solid ${iconColor}33` }"
             >
-              <UIcon :name="icon" class="w-5 h-5" :style="{ color: iconColor }" />
+              <AppIcon :name="icon" class="w-5 h-5" :color="iconColor" />
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-base font-semibold truncate text-(--ui-text)">{{ title }}</p>
@@ -174,8 +174,8 @@ const targetFormatted = computed(() => {
                 : 'bg-(--ui-bg-elevated) text-(--ui-text-dimmed) hover:text-(--ui-text-toned)'"
               @click="manualMode ? switchToPicker() : switchToManual()"
             >
-              <UIcon
-                :name="manualMode ? 'i-heroicons-adjustments-horizontal' : 'i-heroicons-pencil-square'"
+              <AppIcon
+                :name="manualMode ? 'adjustments-horizontal' : 'pencil-square'"
                 class="w-3.5 h-3.5 inline-block mr-1 -mt-0.5"
               />
               {{ manualMode ? 'Picker' : 'Type' }}
@@ -199,7 +199,7 @@ const targetFormatted = computed(() => {
               :class="{ 'opacity-30 pointer-events-none': pickerValue <= min }"
               @click="quickAdjust(-1)"
             >
-              <UIcon name="i-heroicons-minus" class="w-4 h-4" />
+              <AppIcon name="minus" class="w-4 h-4" />
             </button>
 
             <!-- Scroll picker -->
@@ -220,7 +220,7 @@ const targetFormatted = computed(() => {
               :class="{ 'opacity-30 pointer-events-none': pickerValue >= max }"
               @click="quickAdjust(1)"
             >
-              <UIcon name="i-heroicons-plus" class="w-4 h-4" />
+              <AppIcon name="plus" class="w-4 h-4" />
             </button>
           </div>
 

--- a/app/components/TodoCalendarView.vue
+++ b/app/components/TodoCalendarView.vue
@@ -295,12 +295,12 @@ function onDayClick(date: string) {
             <button
               class="p-1.5 rounded-lg hover:bg-(--ui-bg-elevated) text-(--ui-text-toned) transition-colors"
               @click="prevPeriod"
-            ><UIcon name="i-heroicons-chevron-left" class="w-4 h-4" /></button>
+            ><AppIcon name="chevron-left" class="w-4 h-4" /></button>
             <span class="text-sm font-semibold text-(--ui-text) text-center w-40 shrink-0">{{ periodLabel }}</span>
             <button
               class="p-1.5 rounded-lg hover:bg-(--ui-bg-elevated) text-(--ui-text-toned) transition-colors"
               @click="nextPeriod"
-            ><UIcon name="i-heroicons-chevron-right" class="w-4 h-4" /></button>
+            ><AppIcon name="chevron-right" class="w-4 h-4" /></button>
           </div>
 
           <!-- Today pill -->
@@ -449,7 +449,7 @@ function onDayClick(date: string) {
                       : 'border-(--ui-border-accented) hover:border-primary-400'"
                     @click.stop="emit('toggle', todo)"
                   >
-                    <UIcon v-if="todo.is_done" name="i-heroicons-check" class="w-3 h-3 text-white" />
+                    <AppIcon v-if="todo.is_done" name="check" class="w-3 h-3 text-white" />
                   </button>
                 </div>
               </template>
@@ -470,11 +470,11 @@ function onDayClick(date: string) {
             @click="unscheduledOpen = !unscheduledOpen"
           >
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-inbox" class="w-4 h-4 text-(--ui-text-dimmed)" />
+              <AppIcon name="inbox" class="w-4 h-4 text-(--ui-text-dimmed)" />
               <span class="text-sm font-medium">Unscheduled</span>
               <span class="text-xs px-1.5 py-0.5 rounded-full bg-(--ui-bg-elevated) text-(--ui-text-muted) font-mono">{{ unscheduledTodos.length }}</span>
             </div>
-            <UIcon :name="unscheduledOpen ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'" class="w-4 h-4 text-(--ui-text-dimmed)" />
+            <AppIcon :name="unscheduledOpen ? 'chevron-up' : 'chevron-down'" class="w-4 h-4 text-(--ui-text-dimmed)" />
           </button>
           <div v-if="unscheduledOpen" class="border-t border-(--ui-border)/60 divide-y divide-(--ui-border)/40">
             <div
@@ -484,7 +484,7 @@ function onDayClick(date: string) {
             >
               <div class="w-1 h-4 rounded-full shrink-0" :class="priorityBarClass(todo.priority)" />
               <span class="text-sm flex-1 truncate">{{ todo.title }}</span>
-              <UButton variant="ghost" color="neutral" size="xs" icon="i-heroicons-pencil" @click="emit('edit', todo)" />
+              <UButton variant="ghost" color="neutral" size="xs" :icon="resolveIcon('pencil')" @click="emit('edit', todo)" />
             </div>
           </div>
         </div>
@@ -494,7 +494,7 @@ function onDayClick(date: string) {
       <!-- ── Desktop: Unscheduled sidebar ───────────────────────────────────── -->
       <div v-if="unscheduledTodos.length > 0" class="hidden sm:flex sm:flex-col gap-2 w-48 shrink-0">
         <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed) flex items-center gap-1.5">
-          <UIcon name="i-heroicons-inbox" class="w-3.5 h-3.5" />
+          <AppIcon name="inbox" class="w-3.5 h-3.5" />
           Unscheduled
           <span class="ml-auto font-mono font-normal normal-case tracking-normal">{{ unscheduledTodos.length }}</span>
         </p>
@@ -532,13 +532,13 @@ function onDayClick(date: string) {
                 size="xs"
                 variant="soft"
                 color="primary"
-                icon="i-heroicons-plus"
+                :icon="resolveIcon('plus')"
                 @click="openDayCreate"
               >Add</UButton>
               <button
                 class="p-1.5 rounded-lg hover:bg-(--ui-bg-elevated) text-(--ui-text-dimmed) transition-colors"
                 @click="selectedDay = null"
-              ><UIcon name="i-heroicons-x-mark" class="w-4 h-4" /></button>
+              ><AppIcon name="x-mark" class="w-4 h-4" /></button>
             </div>
           </div>
 
@@ -555,7 +555,7 @@ function onDayClick(date: string) {
                 :class="todo.is_done ? 'border-green-500 bg-green-500' : 'border-(--ui-border-accented) hover:border-primary-400'"
                 @click="emit('toggle', todo)"
               >
-                <UIcon v-if="todo.is_done" name="i-heroicons-check" class="w-3 h-3 text-white" />
+                <AppIcon v-if="todo.is_done" name="check" class="w-3 h-3 text-white" />
               </button>
               <div class="flex-1 min-w-0">
                 <p
@@ -567,13 +567,13 @@ function onDayClick(date: string) {
                   <span v-if="todo.estimated_minutes" class="text-xs text-(--ui-text-dimmed) shrink-0">{{ todo.estimated_minutes }}m</span>
                 </div>
               </div>
-              <UButton variant="ghost" color="neutral" size="xs" icon="i-heroicons-pencil" @click="emit('edit', todo)" />
+              <UButton variant="ghost" color="neutral" size="xs" :icon="resolveIcon('pencil')" @click="emit('edit', todo)" />
             </div>
 
             <!-- Empty state -->
             <div v-if="selectedDayTodos.length === 0" class="flex flex-col items-center gap-3 py-10 text-(--ui-text-dimmed)">
               <p class="text-sm">No TODOs for this day.</p>
-              <UButton size="sm" variant="soft" color="primary" icon="i-heroicons-plus" @click="openDayCreate">
+              <UButton size="sm" variant="soft" color="primary" :icon="resolveIcon('plus')" @click="openDayCreate">
                 Add one
               </UButton>
             </div>

--- a/app/composables/useNotifications.ts
+++ b/app/composables/useNotifications.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from '@capacitor/core'
 import { reactive, readonly, ref } from 'vue'
+import { resolveIcon } from '~/utils/icons'
 
 // ─── Module-level singletons ──────────────────────────────────────────────────
 // Persists across composable calls so permission state stays in sync and timers
@@ -444,7 +445,7 @@ export function useNotifications() {
     function showNotif(title: string, body: string) {
       notifLog('fire', `${title}: ${body}`)
       if (toastOnly) {
-        toast.add({ title, description: body, icon: 'i-heroicons-bell', color: 'primary' })
+        toast.add({ title, description: body, icon: resolveIcon('bell'), color: 'primary' })
         return
       }
       if (Notification.permission !== 'granted') return
@@ -587,7 +588,7 @@ export function useNotifications() {
 
     if (typeof Notification === 'undefined') {
       notifLog('test', 'Notification API unavailable — using toast fallback')
-      toast.add({ title, description: body, icon: 'i-heroicons-bell', color: 'primary' })
+      toast.add({ title, description: body, icon: resolveIcon('bell'), color: 'primary' })
       return
     }
     _permission.value = Notification.permission

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -372,7 +372,7 @@ function toggleColorMode() {
           <path class="sprout-soil" d="M 8,40 C 12,37 28,37 32,40" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="round" pathLength="1" />
         </svg>
         <span v-if="!filterStripVisible" class="text-lg font-semibold tracking-tight">Habitat</span>
-        <UIcon v-else name="i-heroicons-tag" class="w-4 h-4 text-(--ui-text-muted)" aria-hidden="true" />
+        <AppIcon v-else name="tag" class="w-4 h-4 text-(--ui-text-muted)" aria-hidden="true" />
       </div>
 
       <!-- Middle: context filter chip strip (flex-1, only when strip open) -->
@@ -438,7 +438,7 @@ function toggleColorMode() {
         <!-- Quick Focus (if not active, or even if active to change?) we only show if not active? Actually it's an option 'where we added global search for quick focus modes' -->
         <div v-if="settings.enableTimer && !timerComp.isActive" class="relative">
           <UButton
-            icon="i-heroicons-clock"
+            :icon="resolveIcon('clock')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -457,17 +457,17 @@ function toggleColorMode() {
               class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted) flex items-center gap-2 text-(--ui-text)"
               @click="startQuickFocus('stopwatch')"
             >
-              <UIcon name="i-heroicons-play" class="w-4 h-4" /> Stopwatch
+              <AppIcon name="play" class="w-4 h-4" /> Stopwatch
             </button>
             <div class="flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted) text-(--ui-text)">
-              <UIcon name="i-heroicons-clock" class="w-4 h-4 shrink-0" />
+              <AppIcon name="clock" class="w-4 h-4 shrink-0" />
               <div class="flex items-center gap-1">
                 <button
                   class="w-6 h-6 rounded-md bg-(--ui-bg-elevated) border border-(--ui-border) flex items-center justify-center text-(--ui-text-muted) hover:text-(--ui-text) transition-colors active:scale-90"
                   :class="{ 'opacity-30 pointer-events-none': quickFocusMinutes <= 5 }"
                   @click="quickFocusMinutes = Math.max(5, quickFocusMinutes - 5)"
                 >
-                  <UIcon name="i-heroicons-minus" class="w-3 h-3" />
+                  <AppIcon name="minus" class="w-3 h-3" />
                 </button>
                 <span class="w-10 text-center font-semibold type-numeric">{{ quickFocusMinutes }}</span>
                 <button
@@ -475,7 +475,7 @@ function toggleColorMode() {
                   :class="{ 'opacity-30 pointer-events-none': quickFocusMinutes >= 120 }"
                   @click="quickFocusMinutes = Math.min(120, quickFocusMinutes + 5)"
                 >
-                  <UIcon name="i-heroicons-plus" class="w-3 h-3" />
+                  <AppIcon name="plus" class="w-3 h-3" />
                 </button>
               </div>
               <span class="text-(--ui-text-muted) text-xs">min</span>
@@ -492,7 +492,7 @@ function toggleColorMode() {
 
         <!-- Global search -->
         <UButton
-          icon="i-heroicons-magnifying-glass"
+          :icon="resolveIcon('magnifying-glass')"
           variant="ghost"
           color="neutral"
           size="sm"
@@ -504,7 +504,7 @@ function toggleColorMode() {
         <!-- Context filter toggle (only when feature on and tags exist) -->
         <UButton
           v-if="settings.enableContextFilter && contextTags.length > 0"
-          :icon="showFilterStrip ? 'i-heroicons-x-mark' : 'i-heroicons-tag'"
+          :icon="resolveIcon(showFilterStrip ? 'x-mark' : 'tag')"
           variant="ghost"
           color="neutral"
           size="sm"
@@ -516,7 +516,7 @@ function toggleColorMode() {
 
         <!-- Dark / light mode toggle -->
         <UButton
-          :icon="colorMode.value === 'dark' ? 'i-heroicons-sun' : 'i-heroicons-moon'"
+          :icon="resolveIcon(colorMode.value === 'dark' ? 'sun' : 'moon')"
           variant="ghost"
           color="neutral"
           size="sm"
@@ -528,7 +528,7 @@ function toggleColorMode() {
         <!-- Theme picker -->
         <div class="relative">
           <UButton
-            icon="i-heroicons-swatch"
+            :icon="resolveIcon('swatch')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -576,7 +576,7 @@ function toggleColorMode() {
                 ? 'border-primary-500 bg-primary-500/15 text-primary-400'
                 : 'border-(--ui-border-accented) text-(--ui-text-muted) hover:border-(--ui-border-accented) hover:text-(--ui-text)'"
             >
-              <UIcon name="i-heroicons-user-circle" class="w-5 h-5" />
+              <AppIcon name="user-circle" class="w-5 h-5" />
             </span>
           </button>
           <!-- Backdrop -->
@@ -598,7 +598,7 @@ function toggleColorMode() {
                 : 'text-(--ui-text) hover:bg-(--ui-bg-elevated)'"
               @click="showAvatarMenu = false"
             >
-              <UIcon name="i-heroicons-calendar-days" class="w-4 h-4" />
+              <AppIcon name="calendar-days" class="w-4 h-4" />
               Matrix
             </NuxtLink>
             <NuxtLink
@@ -609,7 +609,7 @@ function toggleColorMode() {
                 : 'text-(--ui-text) hover:bg-(--ui-bg-elevated)'"
               @click="showAvatarMenu = false"
             >
-              <UIcon name="i-heroicons-chart-bar" class="w-4 h-4" />
+              <AppIcon name="chart-bar" class="w-4 h-4" />
               Stats
             </NuxtLink>
             <NuxtLink
@@ -620,7 +620,7 @@ function toggleColorMode() {
                 : 'text-(--ui-text) hover:bg-(--ui-bg-elevated)'"
               @click="showAvatarMenu = false"
             >
-              <UIcon name="i-heroicons-cog-6-tooth" class="w-4 h-4" />
+              <AppIcon name="cog-6-tooth" class="w-4 h-4" />
               Settings
             </NuxtLink>
           </div>
@@ -636,7 +636,7 @@ function toggleColorMode() {
       <div class="modal-backdrop absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeSearch" />
       <div class="relative w-full max-w-md mx-4 bg-(--ui-bg-muted) border border-(--ui-border) rounded-2xl overflow-hidden shadow-2xl">
         <div class="flex items-center gap-2 px-3 py-2 border-b border-(--ui-border)">
-          <UIcon name="i-heroicons-magnifying-glass" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
+          <AppIcon name="magnifying-glass" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
           <!-- eslint-disable-next-line vuejs-accessibility/no-autofocus -->
           <input
             v-model="searchQuery"
@@ -645,7 +645,7 @@ function toggleColorMode() {
             class="flex-1 bg-transparent text-sm text-(--ui-text) placeholder:text-(--ui-text-dimmed) outline-none"
             @keydown.escape="closeSearch"
           />
-          <UIcon v-if="searchLoading" name="i-heroicons-arrow-path" class="w-4 h-4 animate-spin text-(--ui-text-dimmed) shrink-0" />
+          <AppIcon v-if="searchLoading" name="arrow-path" class="w-4 h-4 animate-spin text-(--ui-text-dimmed) shrink-0" />
         </div>
         <ul v-if="searchResults.length" class="max-h-[60dvh] overflow-y-auto overscroll-contain divide-y divide-(--ui-border)/40">
           <li v-for="r in searchResults" :key="`${r.kind}-${r.id}`">
@@ -654,8 +654,8 @@ function toggleColorMode() {
               class="flex items-center gap-3 px-4 py-2.5 hover:bg-(--ui-bg-elevated) transition-colors"
               @click="closeSearch"
             >
-              <UIcon
-                :name="r.kind === 'habit' ? (r.icon || 'i-heroicons-star') : r.kind === 'todo' ? 'i-heroicons-check-circle' : r.kind === 'scribble' ? 'i-heroicons-document-text' : 'i-heroicons-pencil-square'"
+              <AppIcon
+                :name="r.kind === 'habit' ? (r.icon || 'star') : r.kind === 'todo' ? 'check-circle' : r.kind === 'scribble' ? 'document-text' : 'pencil-square'"
                 class="w-4 h-4 shrink-0"
                 :class="r.kind === 'habit' ? 'text-primary-400' : 'text-(--ui-text-dimmed)'"
               />
@@ -682,7 +682,7 @@ function toggleColorMode() {
       description="Habitat requires the Origin Private File System (OPFS) API, which is not available in this browser. Please use a modern browser such as Chrome, Firefox, or Safari 17+."
       color="error"
       variant="soft"
-      icon="i-heroicons-exclamation-triangle"
+      :icon="resolveIcon('exclamation-triangle')"
       class="rounded-none border-0 border-b border-red-900/50"
     />
     <UAlert
@@ -690,7 +690,7 @@ function toggleColorMode() {
       :description="$dbError"
       color="error"
       variant="soft"
-      icon="i-heroicons-exclamation-triangle"
+      :icon="resolveIcon('exclamation-triangle')"
       class="rounded-none border-0 border-b border-red-900/50"
     />
     <UAlert
@@ -699,8 +699,8 @@ function toggleColorMode() {
       description="Your browser appears to have cleared on-device storage. If data is missing, use Export in Settings regularly to back up."
       color="warning"
       variant="soft"
-      icon="i-heroicons-exclamation-triangle"
-      :close-button="{ icon: 'i-heroicons-x-mark', variant: 'ghost', color: 'neutral', size: 'sm' }"
+      :icon="resolveIcon('exclamation-triangle')"
+      :close-button="{ icon: resolveIcon('x-mark'), variant: 'ghost', color: 'neutral', size: 'sm' }"
       class="rounded-none border-0 border-b border-amber-900/50"
       @close="evictionDetected = false"
     />
@@ -754,7 +754,7 @@ function toggleColorMode() {
           : undefined"
       >
         <span class="text-xs text-(--ui-text-muted) flex items-center gap-1.5">
-          <UIcon name="i-heroicons-arrows-right-left" class="w-3.5 h-3.5" />
+          <AppIcon name="arrows-right-left" class="w-3.5 h-3.5" />
           Drag to reorder tabs
         </span>
         <button

--- a/app/pages/archive.vue
+++ b/app/pages/archive.vue
@@ -85,7 +85,7 @@ onMounted(loadHabits)
     <template v-if="tab === 'habits'">
       <EmptyState
         v-if="!loadingHabits && archivedHabits.length === 0"
-        icon="i-heroicons-archive-box"
+        icon="archive-box"
         title="No archived habits yet"
         description="Habits you archive will appear here."
       />
@@ -100,7 +100,7 @@ onMounted(loadHabits)
             class="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center opacity-60"
             :style="{ backgroundColor: habit.color + '33' }"
           >
-            <UIcon :name="habit.icon" class="w-5 h-5" :style="{ color: habit.color }" />
+            <AppIcon :name="habit.icon" :color="habit.color" class="w-5 h-5" />
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-(--ui-text-muted) truncate">{{ habit.name }}</p>
@@ -115,12 +115,12 @@ onMounted(loadHabits)
     <!-- ── Check-in tab ─────────────────────────────────────────────────────────── -->
     <template v-else>
       <div v-if="loadingCheckins" class="flex items-center gap-2 text-xs text-(--ui-text-dimmed) py-4">
-        <UIcon name="i-heroicons-arrow-path" class="w-3.5 h-3.5 animate-spin" />
+        <AppIcon name="arrow-path" class="w-3.5 h-3.5 animate-spin" />
         Loading…
       </div>
       <EmptyState
         v-else-if="checkinDays.length === 0"
-        icon="i-heroicons-pencil-square"
+        icon="pencil-square"
         title="No check-in responses yet"
         description="Completed check-ins will appear here."
       />
@@ -132,7 +132,7 @@ onMounted(loadHabits)
           class="flex items-center gap-3 p-3 rounded-xl bg-(--ui-bg-muted) border border-(--ui-border)"
         >
           <div class="w-9 h-9 rounded-full bg-(--ui-bg-elevated) flex items-center justify-center flex-shrink-0">
-            <UIcon name="i-heroicons-pencil-square" class="w-4 h-4 text-(--ui-text-muted)" />
+            <AppIcon name="pencil-square" class="w-4 h-4 text-(--ui-text-muted)" />
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-(--ui-text-toned) truncate">{{ day.label }}</p>

--- a/app/pages/bored/activities.vue
+++ b/app/pages/bored/activities.vue
@@ -28,7 +28,7 @@ const activityTitleError = ref<string | null>(null)
 const categoryNameError = ref<string | null>(null)
 
 // Category form
-const catForm = reactive({ name: '', icon: 'i-heroicons-sparkles', color: '#6366f1' })
+const catForm = reactive({ name: '', icon: resolveIcon('sparkles'), color: '#6366f1' })
 
 // Activity form
 const actForm = reactive({
@@ -86,7 +86,7 @@ function openEditActivity(a: BoredActivity) {
 function openAddCategory() {
   editingCategory.value = null
   categoryNameError.value = null
-  Object.assign(catForm, { name: '', icon: 'i-heroicons-sparkles', color: '#6366f1' })
+  Object.assign(catForm, { name: '', icon: resolveIcon('sparkles'), color: '#6366f1' })
   showCategoryModal.value = true
 }
 
@@ -199,7 +199,7 @@ async function archiveActivity(a: BoredActivity) {
 <template>
   <div class="max-w-lg mx-auto space-y-6">
     <div class="flex items-center gap-3">
-      <UButton to="/bored" variant="ghost" color="neutral" size="sm" icon="i-heroicons-arrow-left" />
+      <UButton to="/bored" variant="ghost" color="neutral" size="sm" :icon="resolveIcon('arrow-left')" />
       <h1 class="text-xl font-bold">Manage Activities</h1>
     </div>
 
@@ -207,7 +207,7 @@ async function archiveActivity(a: BoredActivity) {
     <div v-for="cat in categories" :key="cat.id" class="space-y-2">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
-          <UIcon :name="cat.icon" class="w-4 h-4" :style="{ color: cat.color }" />
+          <AppIcon :name="cat.icon" class="w-4 h-4" :color="cat.color" />
           <span class="font-semibold text-sm">{{ cat.name }}</span>
           <span class="text-xs text-(--ui-text-dimmed)">({{ activitiesForCategory(cat.id).length }})</span>
         </div>
@@ -217,7 +217,7 @@ async function archiveActivity(a: BoredActivity) {
             variant="ghost"
             color="neutral"
             size="sm"
-            icon="i-heroicons-pencil"
+            :icon="resolveIcon('pencil')"
             @click="openEditCategory(cat)"
           />
           <UButton
@@ -225,14 +225,14 @@ async function archiveActivity(a: BoredActivity) {
             variant="ghost"
             color="error"
             size="sm"
-            icon="i-heroicons-trash"
+            :icon="resolveIcon('trash')"
             @click="confirmDeleteCategory = cat"
           />
           <UButton
             variant="ghost"
             color="neutral"
             size="sm"
-            icon="i-heroicons-plus"
+            :icon="resolveIcon('plus')"
             @click="openAddActivity(cat.id)"
           />
         </div>
@@ -253,7 +253,7 @@ async function archiveActivity(a: BoredActivity) {
                 {{ act.estimated_minutes }}m
               </span>
               <span v-if="act.is_recurring" class="text-xs text-(--ui-text-dimmed) flex items-center gap-0.5">
-                <UIcon name="i-heroicons-arrow-path" class="w-3 h-3" />
+                <AppIcon name="arrow-path" class="w-3 h-3" />
                 {{ act.recurrence_rule }}
               </span>
               <span v-if="act.done_count > 0" class="text-xs text-(--ui-text-dimmed)">
@@ -262,9 +262,9 @@ async function archiveActivity(a: BoredActivity) {
             </div>
           </div>
           <div class="flex items-center gap-1 ml-2 shrink-0">
-            <UButton variant="ghost" color="neutral" size="sm" icon="i-heroicons-pencil" @click="openEditActivity(act)" />
-            <UButton variant="ghost" color="neutral" size="sm" icon="i-heroicons-archive-box" @click="confirmArchiveActivity = act" />
-            <UButton variant="ghost" color="error" size="sm" icon="i-heroicons-trash" @click="confirmDeleteActivity = act" />
+            <UButton variant="ghost" color="neutral" size="sm" :icon="resolveIcon('pencil')" @click="openEditActivity(act)" />
+            <UButton variant="ghost" color="neutral" size="sm" :icon="resolveIcon('archive-box')" @click="confirmArchiveActivity = act" />
+            <UButton variant="ghost" color="error" size="sm" :icon="resolveIcon('trash')" @click="confirmDeleteActivity = act" />
           </div>
         </div>
         <div v-if="activitiesForCategory(cat.id).length === 0" class="text-xs text-slate-600 px-1">
@@ -278,7 +278,7 @@ async function archiveActivity(a: BoredActivity) {
       variant="soft"
       color="neutral"
       size="sm"
-      icon="i-heroicons-plus"
+      :icon="resolveIcon('plus')"
       class="w-full"
       @click="openAddCategory"
     >
@@ -293,7 +293,7 @@ async function archiveActivity(a: BoredActivity) {
             <UInput v-model="catForm.name" placeholder="Category name" class="w-full" />
           </UFormField>
           <p v-if="categoryNameError" class="text-xs text-red-400 -mt-2 flex items-center gap-1">
-            <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
+            <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
             {{ categoryNameError }}
           </p>
           <UFormField label="Icon (Heroicons class)">
@@ -321,7 +321,7 @@ async function archiveActivity(a: BoredActivity) {
             <UInput v-model="actForm.title" placeholder="Activity title" class="w-full" />
           </UFormField>
           <p v-if="activityTitleError" class="text-xs text-red-400 -mt-2 flex items-center gap-1">
-            <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
+            <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
             {{ activityTitleError }}
           </p>
           <UFormField label="Description">
@@ -363,7 +363,7 @@ async function archiveActivity(a: BoredActivity) {
     <!-- Delete activity confirm -->
     <ConfirmDialog
       :open="!!confirmDeleteActivity"
-      icon="i-heroicons-trash"
+      icon="trash"
       icon-color="red"
       :title="`Delete &quot;${confirmDeleteActivity?.title}&quot;?`"
       message="This cannot be undone."
@@ -377,7 +377,7 @@ async function archiveActivity(a: BoredActivity) {
     <!-- Delete category confirm -->
     <ConfirmDialog
       :open="!!confirmDeleteCategory"
-      icon="i-heroicons-trash"
+      icon="trash"
       icon-color="red"
       :title="`Delete &quot;${confirmDeleteCategory?.name}&quot;?`"
       message="All activities in this category will also be deleted."
@@ -391,7 +391,7 @@ async function archiveActivity(a: BoredActivity) {
     <!-- Archive activity confirm -->
     <ConfirmDialog
       :open="!!confirmArchiveActivity"
-      icon="i-heroicons-archive-box"
+      icon="archive-box"
       icon-color="amber"
       :title="`Archive &quot;${confirmArchiveActivity?.title}&quot;?`"
       message="Archived activities won't appear in the oracle."

--- a/app/pages/bored/index.vue
+++ b/app/pages/bored/index.vue
@@ -303,7 +303,7 @@ const oracleHint = computed(() => {
     <!-- Header -->
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold">I'm Bored</h1>
-      <UButton to="/bored/activities" variant="ghost" color="neutral" size="sm" icon="i-heroicons-cog-6-tooth">
+      <UButton to="/bored/activities" variant="ghost" color="neutral" size="sm" :icon="resolveIcon('cog-6-tooth')">
         Manage
       </UButton>
     </div>
@@ -335,7 +335,7 @@ const oracleHint = computed(() => {
         :style="excludedCategories.includes(cat.id) ? {} : { backgroundColor: cat.color + '33', borderColor: cat.color + '88', color: cat.color }"
         @click="toggleCategory(cat.id); selectionChanged()"
       >
-        <UIcon :name="cat.icon" class="w-3.5 h-3.5" />
+        <AppIcon :name="cat.icon" class="w-3.5 h-3.5" />
         {{ cat.name }}
       </button>
     </div>
@@ -362,11 +362,11 @@ const oracleHint = computed(() => {
           <div v-if="eggActive === 'hab-eight'" class="egg-eight">8</div>
           <div v-else-if="eggActive === 'hab-certain'" class="egg-certain-flash" />
           <div v-else-if="currentResult && !shaking" class="result-content">
-            <UIcon
+            <AppIcon
               v-if="resultCategory"
               :name="resultCategory.icon"
               class="w-8 h-8 shrink-0"
-              :style="{ color: resultCategory.color }"
+              :color="resultCategory.color"
             />
             <span
               v-if="resultCategory"
@@ -397,11 +397,11 @@ const oracleHint = computed(() => {
         <div class="stone-face">
           <span v-if="eggActive === 'for-thirteenth'" class="rune-ancient">ᚱ</span>
           <div v-else-if="currentResult && !shaking" class="rune-result">
-            <UIcon
+            <AppIcon
               v-if="resultCategory"
               :name="resultCategory.icon"
               class="w-8 h-8 shrink-0"
-              :style="{ color: resultCategory.color }"
+              :color="resultCategory.color"
             />
             <span
               v-if="resultCategory"
@@ -440,11 +440,11 @@ const oracleHint = computed(() => {
             <div class="jelly-rim-glow" />
             <div class="jelly-face">
               <div v-if="currentResult && !shaking" class="jelly-result">
-                <UIcon
+                <AppIcon
                   v-if="resultCategory"
                   :name="resultCategory.icon"
                   class="w-7 h-7 shrink-0"
-                  :style="{ color: resultCategory.color }"
+                  :color="resultCategory.color"
                 />
                 <span
                   v-if="resultCategory"
@@ -489,11 +489,11 @@ const oracleHint = computed(() => {
               class="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium"
               :style="{ backgroundColor: resultCategory.color + '22', color: resultCategory.color }"
             >
-              <UIcon :name="resultCategory.icon" class="w-3 h-3" />
+              <AppIcon :name="resultCategory.icon" class="w-3 h-3" />
               {{ resultCategory.name }}
             </span>
             <span v-if="resultEstimate" class="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-(--ui-bg-elevated) text-(--ui-text-toned)">
-              <UIcon name="i-heroicons-clock" class="w-3 h-3" />
+              <AppIcon name="clock" class="w-3 h-3" />
               {{ resultEstimate }}
             </span>
             <span v-if="currentResult.source === 'todo'" class="text-xs px-2 py-0.5 rounded-full bg-blue-900/40 text-blue-300">
@@ -528,7 +528,7 @@ const oracleHint = computed(() => {
               size="sm"
               variant="ghost"
               color="neutral"
-              :icon="timer.isRunning ? 'i-heroicons-pause' : 'i-heroicons-play'"
+              :icon="resolveIcon(timer.isRunning ? 'pause' : 'play')"
               :aria-label="timer.isRunning ? 'Pause timer' : 'Resume timer'"
               @click="timer.isRunning ? timer.pauseTimer() : timer.resumeTimer()"
             />
@@ -536,7 +536,7 @@ const oracleHint = computed(() => {
               size="sm"
               variant="soft"
               color="success"
-              icon="i-heroicons-check"
+              :icon="resolveIcon('check')"
               :loading="marking"
               @click="finishBoredTimerAndDone"
             >Done</UButton>
@@ -544,7 +544,7 @@ const oracleHint = computed(() => {
               size="sm"
               variant="ghost"
               color="neutral"
-              icon="i-heroicons-x-mark"
+              :icon="resolveIcon('x-mark')"
               aria-label="Stop timer"
               @click="timer.stopTimer()"
             />
@@ -556,7 +556,7 @@ const oracleHint = computed(() => {
               variant="soft"
               color="success"
               size="sm"
-              icon="i-heroicons-check"
+              :icon="resolveIcon('check')"
               :loading="marking"
               @click="markDone"
             >
@@ -570,7 +570,7 @@ const oracleHint = computed(() => {
                 size="sm"
                 variant="soft"
                 color="neutral"
-                icon="i-heroicons-play"
+                :icon="resolveIcon('play')"
                 @click="handleBoredStart"
                 @pointerdown="startLongPress"
                 @pointerup="cancelLongPress"
@@ -587,10 +587,10 @@ const oracleHint = computed(() => {
                   class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted) flex items-center gap-2"
                   @click="startBoredMode('stopwatch')"
                 >
-                  <UIcon name="i-heroicons-play" class="w-4 h-4" /> Stopwatch
+                  <AppIcon name="play" class="w-4 h-4" /> Stopwatch
                 </button>
                 <div role="menuitem" class="flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted)">
-                  <UIcon name="i-heroicons-clock" class="w-4 h-4 shrink-0" />
+                  <AppIcon name="clock" class="w-4 h-4 shrink-0" />
                   <input
                     v-model.number="modeMenuMinutes"
                     type="number"
@@ -617,7 +617,7 @@ const oracleHint = computed(() => {
               variant="soft"
               color="neutral"
               size="sm"
-              icon="i-heroicons-arrow-path"
+              :icon="resolveIcon('arrow-path')"
               @click="roll"
             >
               Roll again
@@ -628,7 +628,7 @@ const oracleHint = computed(() => {
               variant="ghost"
               color="neutral"
               size="sm"
-              icon="i-heroicons-arrow-right"
+              :icon="resolveIcon('arrow-right')"
             >
               View TODO
             </UButton>
@@ -638,7 +638,7 @@ const oracleHint = computed(() => {
               variant="ghost"
               color="neutral"
               size="sm"
-              icon="i-heroicons-arrow-right"
+              :icon="resolveIcon('arrow-right')"
             >
               View all
             </UButton>

--- a/app/pages/checkin/[id].vue
+++ b/app/pages/checkin/[id].vue
@@ -323,12 +323,12 @@ onMounted(async () => {
 
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center py-12">
-      <UIcon name="i-heroicons-arrow-path" class="w-5 h-5 animate-spin text-slate-600" />
+      <AppIcon name="arrow-path" class="w-5 h-5 animate-spin text-slate-600" />
     </div>
 
     <!-- Not found -->
     <div v-else-if="!template" class="flex flex-col items-center gap-3 py-12 text-center">
-      <UIcon name="i-heroicons-exclamation-circle" class="w-8 h-8 text-slate-700" />
+      <AppIcon name="exclamation-circle" class="w-8 h-8 text-slate-700" />
       <p class="text-sm text-(--ui-text-dimmed)">Check-in not found.</p>
       <UButton variant="ghost" color="neutral" size="sm" to="/checkin">Go back</UButton>
     </div>
@@ -343,21 +343,21 @@ onMounted(async () => {
         </div>
         <div class="flex items-center gap-0.5 mt-1">
           <UButton
-            icon="i-heroicons-pencil-square"
+            :icon="resolveIcon('pencil-square')"
             variant="ghost"
             color="neutral"
             size="sm"
             @click="openEdit"
           />
           <UButton
-            icon="i-heroicons-chevron-left"
+            :icon="resolveIcon('chevron-left')"
             variant="ghost"
             color="neutral"
             size="sm"
             @click="prevDay"
           />
           <UButton
-            icon="i-heroicons-chevron-right"
+            :icon="resolveIcon('chevron-right')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -376,7 +376,7 @@ onMounted(async () => {
           v-if="questions.length === 0"
           class="flex flex-col items-center gap-3 py-8 text-center"
         >
-          <UIcon name="i-heroicons-plus-circle" class="w-7 h-7 text-slate-700" />
+          <AppIcon name="plus-circle" class="w-7 h-7 text-slate-700" />
           <p class="text-sm text-(--ui-text-dimmed)">No questions yet. Add one below.</p>
         </div>
 
@@ -393,7 +393,7 @@ onMounted(async () => {
               :disabled="deletingQuestion.has(q.id)"
               @click="deleteQuestion(q.id)"
             >
-              <UIcon name="i-heroicons-trash" class="w-3.5 h-3.5" />
+              <AppIcon name="trash" class="w-3.5 h-3.5" />
             </button>
           </div>
 
@@ -434,7 +434,7 @@ onMounted(async () => {
                 class="flex items-center gap-1 text-xs text-green-400 mt-1"
                 aria-live="polite"
               >
-                <UIcon name="i-heroicons-check" class="w-3 h-3" />
+                <AppIcon name="check" class="w-3 h-3" />
                 Saved
               </span>
             </Transition>
@@ -472,7 +472,7 @@ onMounted(async () => {
             size="xs"
             variant="ghost"
             color="neutral"
-            :icon="showAddQuestion ? 'i-heroicons-chevron-up' : 'i-heroicons-plus'"
+            :icon="resolveIcon(showAddQuestion ? 'chevron-up' : 'plus')"
             @click="showAddQuestion = !showAddQuestion"
           />
         </div>
@@ -523,7 +523,7 @@ onMounted(async () => {
             size="xs"
             variant="ghost"
             color="neutral"
-            :icon="showAddReminder ? 'i-heroicons-chevron-up' : 'i-heroicons-plus'"
+            :icon="resolveIcon(showAddReminder ? 'chevron-up' : 'plus')"
             @click="showAddReminder = !showAddReminder"
           />
         </div>
@@ -542,7 +542,7 @@ onMounted(async () => {
             :disabled="deletingReminder.has(r.id)"
             @click="removeReminder(r.id)"
           >
-            <UIcon name="i-heroicons-trash" class="w-4 h-4" />
+            <AppIcon name="trash" class="w-4 h-4" />
           </button>
         </div>
 
@@ -580,7 +580,7 @@ onMounted(async () => {
           variant="soft"
           color="error"
           size="sm"
-          icon="i-heroicons-trash"
+          :icon="resolveIcon('trash')"
           @click="showDeleteConfirm = true"
         >
           Delete check-in
@@ -593,7 +593,7 @@ onMounted(async () => {
     <AppModal v-model="showEdit">
         <div class="flex items-center justify-between">
           <h3 class="font-semibold text-(--ui-text)">Edit Check-in</h3>
-          <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showEdit = false" />
+          <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showEdit = false" />
         </div>
 
         <UInput v-model="editTitle" placeholder="Name" @keydown.enter="saveEdit" />
@@ -621,7 +621,7 @@ onMounted(async () => {
     <!-- ── Delete confirm ─────────────────────────────────────────────────── -->
     <ConfirmDialog
       :open="showDeleteConfirm"
-      icon="i-heroicons-trash"
+      icon="trash"
       icon-color="red"
       :title="`Delete &quot;${template?.title}&quot;?`"
       message="This will delete the check-in along with all its questions and responses. This cannot be undone."

--- a/app/pages/checkin/index.vue
+++ b/app/pages/checkin/index.vue
@@ -68,7 +68,7 @@ async function createTemplate() {
     <header class="flex items-center justify-between">
       <h2 class="text-2xl font-bold">Check-in</h2>
       <UButton
-        icon="i-heroicons-plus"
+        :icon="resolveIcon('plus')"
         variant="soft"
         color="neutral"
         size="sm"
@@ -81,7 +81,7 @@ async function createTemplate() {
 
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center py-12">
-      <UIcon name="i-heroicons-arrow-path" class="w-5 h-5 animate-spin text-slate-600" />
+      <AppIcon name="arrow-path" class="w-5 h-5 animate-spin text-slate-600" />
     </div>
 
     <!-- Template list -->
@@ -99,14 +99,14 @@ async function createTemplate() {
                 {{ checkinScheduleLabel(t) }}<span v-if="t.response_day_count"> · {{ t.response_day_count }} {{ t.response_day_count === 1 ? 'session' : 'sessions' }}</span>
               </p>
             </div>
-            <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
+            <AppIcon name="chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
           </NuxtLink>
         </li>
       </ul>
 
       <EmptyState
         v-if="templates.length === 0"
-        icon="i-heroicons-pencil-square"
+        :icon="resolveIcon('pencil-square')"
         title="No check-ins yet"
         description="Create one to get started."
       />
@@ -116,7 +116,7 @@ async function createTemplate() {
     <AppModal v-model="showCreate">
         <div class="flex items-center justify-between">
           <h3 class="font-semibold text-(--ui-text)">New Check-in</h3>
-          <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showCreate = false" />
+          <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showCreate = false" />
         </div>
 
         <!-- Title -->
@@ -127,7 +127,7 @@ async function createTemplate() {
           @keydown.enter="createTemplate"
         />
         <p v-if="newTitleError" class="text-xs text-red-400 -mt-2 flex items-center gap-1">
-          <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
+          <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
           {{ newTitleError }}
         </p>
 

--- a/app/pages/focus.vue
+++ b/app/pages/focus.vue
@@ -149,7 +149,7 @@ function addOneMinute() {
     <!-- Top Action Bar -->
     <header class="w-full px-4 flex items-center justify-between shrink-0">
       <UButton
-        icon="i-heroicons-chevron-down"
+        :icon="resolveIcon('chevron-down')"
         variant="ghost"
         color="neutral"
         size="lg"
@@ -158,7 +158,7 @@ function addOneMinute() {
         @click="minimize"
       />
       <UButton
-        icon="i-heroicons-x-mark"
+        :icon="resolveIcon('x-mark')"
         variant="ghost"
         color="neutral"
         size="lg"
@@ -247,7 +247,7 @@ function addOneMinute() {
             aria-label="Play/Pause"
             @click="playPause"
           >
-            <UIcon :name="timerComp.isRunning ? 'i-heroicons-pause-16-solid' : 'i-heroicons-play-16-solid'" class="w-8 h-8" />
+            <AppIcon :name="timerComp.isRunning ? 'pause' : 'play'" variant="micro" class="w-8 h-8" />
           </button>
         </div>
       </div>
@@ -258,7 +258,7 @@ function addOneMinute() {
       <template #content>
         <div class="p-6 text-center space-y-5">
           <div class="mx-auto w-12 h-12 bg-red-100 dark:bg-red-900/30 text-red-500 rounded-full flex items-center justify-center mb-2">
-            <UIcon name="i-heroicons-stop-circle" class="w-6 h-6" />
+            <AppIcon name="stop-circle" class="w-6 h-6" />
           </div>
           <h3 class="text-lg font-bold text-(--ui-text)">{{ endModalTitle }}</h3>
           <p class="text-sm text-(--ui-text-muted)">

--- a/app/pages/habits/[id].vue
+++ b/app/pages/habits/[id].vue
@@ -449,7 +449,7 @@ onMounted(load)
           class="w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0"
           :style="{ backgroundColor: habit.color + '33' }"
         >
-          <UIcon :name="habit.icon" class="w-6 h-6" :style="{ color: habit.color }" />
+          <AppIcon :name="habit.icon" :color="habit.color" class="w-6 h-6" />
         </div>
         <div class="flex-1 min-w-0">
           <h2 class="text-xl font-bold truncate">{{ habit.name }}</h2>
@@ -462,7 +462,7 @@ onMounted(load)
         v-if="isPaused"
         class="flex items-center gap-3 p-3 rounded-xl bg-amber-500/10 border border-amber-500/30"
       >
-        <UIcon name="i-heroicons-pause-circle" class="w-5 h-5 text-amber-400 flex-shrink-0" />
+        <AppIcon name="pause-circle" class="w-5 h-5 text-amber-400 flex-shrink-0" />
         <p class="text-sm text-amber-300 flex-1">
           Paused until {{ fmtArchived(habit.paused_until!) }}
         </p>
@@ -492,7 +492,7 @@ onMounted(load)
           v-if="habit.type === 'BOOLEAN'"
           :variant="todayCompleted ? 'soft' : 'solid'"
           :color="todayCompleted ? 'success' : 'primary'"
-          :icon="todayCompleted ? 'i-heroicons-check-circle' : 'i-heroicons-plus-circle'"
+          :icon="resolveIcon(todayCompleted ? 'check-circle' : 'plus-circle')"
           :loading="togglingToday"
           class="w-full justify-center"
           @click="toggleToday"
@@ -505,7 +505,7 @@ onMounted(load)
           <UButton
             variant="soft"
             color="primary"
-            icon="i-heroicons-plus"
+            :icon="resolveIcon('plus')"
             class="w-full justify-center"
             @click="openLogSheet"
           >
@@ -536,7 +536,7 @@ onMounted(load)
             size="sm"
             variant="ghost"
             color="neutral"
-            :icon="showAddReminder ? 'i-heroicons-chevron-up' : 'i-heroicons-plus'"
+            :icon="resolveIcon(showAddReminder ? 'chevron-up' : 'plus')"
             @click="showAddReminder = !showAddReminder"
           />
         </div>
@@ -556,7 +556,7 @@ onMounted(load)
             :disabled="deletingReminder.has(r.id)"
             @click="removeReminder(r.id)"
           >
-            <UIcon name="i-heroicons-trash" class="w-4 h-4" />
+            <AppIcon name="trash" class="w-4 h-4" />
           </button>
         </div>
 
@@ -706,7 +706,7 @@ onMounted(load)
               :disabled="deletingLog.has(entry.id)"
               @click="deleteLog(entry.id)"
             >
-              <UIcon name="i-heroicons-trash" class="w-4 h-4" />
+              <AppIcon name="trash" class="w-4 h-4" />
             </button>
           </div>
         </div>
@@ -820,7 +820,7 @@ onMounted(load)
               class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
               @click="editForm.show_due_time = !editForm.show_due_time"
             >
-              <UIcon :name="editForm.show_due_time ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+              <AppIcon :name="editForm.show_due_time ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5" />
               {{ editForm.show_due_time ? 'Remove due time' : 'Add due time' }}
             </button>
             <div v-if="editForm.show_due_time" class="mt-2">
@@ -834,7 +834,7 @@ onMounted(load)
               class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
               @click="editShowAnnotations = !editShowAnnotations"
             >
-              <UIcon :name="editShowAnnotations ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+              <AppIcon :name="editShowAnnotations ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5" />
               {{ editShowAnnotations ? 'Hide annotations' : editAnnotationEntries.length > 0 ? `Annotations (${editAnnotationEntries.length})` : 'Add annotations' }}
             </button>
             <div v-if="editShowAnnotations" class="mt-2 space-y-1.5">
@@ -843,17 +843,17 @@ onMounted(load)
                 <span class="text-slate-600 text-xs">:</span>
                 <UInput v-model="entry.value" placeholder="value" class="flex-1" />
                 <button class="text-slate-700 hover:text-red-400 transition-colors" @click="removeEditAnnotationEntry(i)">
-                  <UIcon name="i-heroicons-x-mark" class="w-3.5 h-3.5" />
+                  <AppIcon name="x-mark" class="w-3.5 h-3.5" />
                 </button>
               </div>
               <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addEditAnnotationEntry">
-                <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
+                <AppIcon name="plus" class="w-3 h-3" /> Add annotation
               </button>
             </div>
           </div>
 
           <p v-if="editScheduleError" class="text-sm text-red-400 flex items-center gap-1.5">
-            <UIcon name="i-heroicons-exclamation-circle" class="w-4 h-4 flex-shrink-0" />
+            <AppIcon name="exclamation-circle" class="w-4 h-4 flex-shrink-0" />
             {{ editScheduleError }}
           </p>
 
@@ -873,7 +873,7 @@ onMounted(load)
         <div class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-amber-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-pause-circle" class="w-5 h-5 text-amber-400" />
+              <AppIcon name="pause-circle" class="w-5 h-5 text-amber-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Pause "{{ habit?.name }}"</p>
@@ -900,7 +900,7 @@ onMounted(load)
     <!-- ── Archive confirm ─────────────────────────────────────────────────────── -->
     <ConfirmDialog
       :open="showArchiveConfirm"
-      icon="i-heroicons-archive-box"
+      icon="archive-box"
       icon-color="amber"
       :title="`Archive &quot;${habit?.name}&quot;?`"
       message="The habit and all its history will be preserved in your archive."

--- a/app/pages/habits/index.vue
+++ b/app/pages/habits/index.vue
@@ -159,7 +159,7 @@ async function handleCreate() {
       name: form.name.trim(),
       description: form.description.trim(),
       color: '#06b6d4',
-      icon: 'i-heroicons-star',
+      icon: resolveIcon('star'),
       frequency: 'daily',
       tags: [...form.tags],
       annotations: buildAnnotations(annotationEntries.value),
@@ -231,14 +231,14 @@ onMounted(loadHabits)
       <div class="flex items-center gap-2">
         <UButton
           to="/archive"
-          icon="i-heroicons-archive-box"
+          :icon="resolveIcon('archive-box')"
           variant="ghost"
           color="neutral"
           size="sm"
         />
         <UButton
           v-if="anyPaused"
-          icon="i-heroicons-play"
+          :icon="resolveIcon('play')"
           variant="ghost"
           color="neutral"
           size="sm"
@@ -248,20 +248,20 @@ onMounted(loadHabits)
         />
         <UButton
           v-if="habits.length > 0"
-          icon="i-heroicons-pause"
+          :icon="resolveIcon('pause')"
           variant="ghost"
           color="neutral"
           size="sm"
           title="Pause all habits"
           @click="openPauseAll"
         />
-        <UButton icon="i-heroicons-plus" size="sm" class="min-h-[44px]" @click="isOpen = true">New</UButton>
+        <UButton :icon="resolveIcon('plus')" size="sm" class="min-h-[44px]" @click="isOpen = true">New</UButton>
       </div>
     </header>
 
     <EmptyState
       v-if="habits.length === 0"
-      icon="i-heroicons-clipboard-document-list"
+      icon="clipboard-document-list"
       title="No habits yet"
       description="Tap New to create your first habit."
     />
@@ -278,7 +278,7 @@ onMounted(loadHabits)
           class="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0"
           :style="{ backgroundColor: habit.color + '33' }"
         >
-          <UIcon :name="habit.icon" class="w-5 h-5" :style="{ color: habit.color }" />
+          <AppIcon :name="habit.icon" :color="habit.color" class="w-5 h-5" />
         </div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-1.5 min-w-0">
@@ -327,9 +327,9 @@ onMounted(loadHabits)
           :aria-label="`Toggle ${habit.name} for today`"
           @click.prevent="quickToggle(habit, $event)"
         >
-          <UIcon v-if="todayCompletionHabitIds.has(habit.id)" name="i-heroicons-check" class="w-3.5 h-3.5 text-white" />
+          <AppIcon v-if="todayCompletionHabitIds.has(habit.id)" name="check" class="w-3.5 h-3.5 text-white" />
         </button>
-        <UIcon v-else name="i-heroicons-chevron-right" class="w-4 h-4 text-slate-700 flex-shrink-0" />
+        <AppIcon v-else name="chevron-right" class="w-4 h-4 text-slate-700 flex-shrink-0" />
       </NuxtLink>
     </ul>
 
@@ -365,7 +365,7 @@ onMounted(loadHabits)
           <UInput v-model="form.name" placeholder="e.g. Morning run" autofocus />
         </UFormField>
         <p v-if="nameError" class="text-xs text-red-400 -mt-2 flex items-center gap-1">
-          <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
+          <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
           {{ nameError }}
         </p>
 
@@ -455,7 +455,7 @@ onMounted(loadHabits)
             class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
             @click="form.show_due_time = !form.show_due_time"
           >
-            <UIcon :name="form.show_due_time ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+            <AppIcon :name="form.show_due_time ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5" />
             {{ form.show_due_time ? 'Remove due time' : 'Add due time' }}
           </button>
           <div v-if="form.show_due_time" class="mt-2">
@@ -469,7 +469,7 @@ onMounted(loadHabits)
             class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
             @click="showAnnotations = !showAnnotations"
           >
-            <UIcon :name="showAnnotations ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+            <AppIcon :name="showAnnotations ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5" />
             {{ showAnnotations ? 'Hide annotations' : annotationEntries.length > 0 ? `Annotations (${annotationEntries.length})` : 'Add annotations' }}
           </button>
           <div v-if="showAnnotations" class="mt-2 space-y-1.5">
@@ -478,11 +478,11 @@ onMounted(loadHabits)
               <span class="text-slate-600 text-xs">:</span>
               <UInput v-model="entry.value" placeholder="value" class="flex-1" />
               <button class="p-2 -m-1 text-slate-700 hover:text-red-400 transition-colors" @click="removeAnnotationEntry(i)">
-                <UIcon name="i-heroicons-x-mark" class="w-4 h-4" />
+                <AppIcon name="x-mark" class="w-4 h-4" />
               </button>
             </div>
             <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1" @click="addAnnotationEntry">
-              <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add annotation
+              <AppIcon name="plus" class="w-3 h-3" /> Add annotation
             </button>
           </div>
         </div>
@@ -493,7 +493,7 @@ onMounted(loadHabits)
             class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1"
             @click="showAddReminder = !showAddReminder"
           >
-            <UIcon :name="showAddReminder ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
+            <AppIcon :name="showAddReminder ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5" />
             {{ showAddReminder ? 'Hide reminders' : pendingReminders.length > 0 ? `Reminders (${pendingReminders.length})` : 'Add reminders' }}
           </button>
           <div v-if="showAddReminder" class="mt-2 space-y-2">
@@ -503,13 +503,13 @@ onMounted(loadHabits)
               :key="i"
               class="flex items-center gap-2"
             >
-              <UIcon name="i-heroicons-bell" class="w-3.5 h-3.5 text-(--ui-text-dimmed) shrink-0" />
+              <AppIcon name="bell" class="w-3.5 h-3.5 text-(--ui-text-dimmed) shrink-0" />
               <span class="text-sm type-duration text-(--ui-text-toned)">{{ r.time }}</span>
               <span class="text-xs text-(--ui-text-dimmed)">
                 {{ r.days.length ? r.days.map(d => HABIT_DAY_LABELS[d]).join(' ') : 'Every day' }}
               </span>
               <button class="ml-auto p-1.5 -m-1 text-slate-700 hover:text-red-400 transition-colors" @click="removePendingReminder(i)">
-                <UIcon name="i-heroicons-x-mark" class="w-4 h-4" />
+                <AppIcon name="x-mark" class="w-4 h-4" />
               </button>
             </div>
 
@@ -535,7 +535,7 @@ onMounted(loadHabits)
         </div>
 
         <p v-if="scheduleError" class="text-sm text-red-400 flex items-center gap-1.5">
-          <UIcon name="i-heroicons-exclamation-circle" class="w-4 h-4 flex-shrink-0" />
+          <AppIcon name="exclamation-circle" class="w-4 h-4 flex-shrink-0" />
           {{ scheduleError }}
         </p>
 

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -247,9 +247,9 @@ async function saveMeal(value: number) {
 }
 
 const MEAL_ICONS: Record<string, string> = {
-  Breakfast: 'i-heroicons-sun',
-  Lunch: 'i-heroicons-sparkles',
-  Dinner: 'i-heroicons-moon',
+  Breakfast: resolveIcon('sun'),
+  Lunch: resolveIcon('sparkles'),
+  Dinner: resolveIcon('moon'),
 }
 
 onMounted(load)
@@ -268,7 +268,7 @@ onMounted(load)
       class="flex flex-col items-center justify-center gap-4 py-12 text-center"
     >
       <div class="w-16 h-16 rounded-full bg-(--ui-bg-elevated) flex items-center justify-center">
-        <UIcon name="i-heroicons-heart" class="w-8 h-8 text-rose-400" />
+        <AppIcon name="heart" class="w-8 h-8 text-rose-400" />
       </div>
       <div class="space-y-1">
         <p class="font-semibold text-(--ui-text)">No health habits yet</p>
@@ -283,11 +283,11 @@ onMounted(load)
       <UCard v-if="stepsHabit" :ui="{ root: 'rounded-2xl', body: 'p-4 sm:p-4 space-y-4' }">
         <header class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <UIcon name="i-heroicons-fire" class="w-4 h-4 text-rose-400" />
+            <AppIcon name="fire" class="w-4 h-4 text-rose-400" />
             <h3 class="text-xs font-semibold text-(--ui-text-muted) uppercase tracking-wide">Steps Today</h3>
           </div>
           <UButton
-            icon="i-heroicons-pencil-square"
+            :icon="resolveIcon('pencil-square')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -383,7 +383,7 @@ onMounted(load)
       <UCard v-if="waterHabit" :ui="{ root: 'rounded-2xl', body: 'p-4 sm:p-4 space-y-3' }">
         <header class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <UIcon name="i-heroicons-beaker" class="w-4 h-4 text-sky-400" />
+            <AppIcon name="beaker" class="w-4 h-4 text-sky-400" />
             <h3 class="text-xs font-semibold text-(--ui-text-muted) uppercase tracking-wide">Water Today</h3>
           </div>
           <div class="flex items-center gap-2">
@@ -397,14 +397,14 @@ onMounted(load)
                 :disabled="savingWater || waterToday <= 0"
                 @click="setWater(Math.max(0, Math.round(waterToday) - 1))"
               >
-                <UIcon name="i-heroicons-minus" class="w-3.5 h-3.5" />
+                <AppIcon name="minus" class="w-3.5 h-3.5" />
               </button>
               <button
                 class="w-7 h-7 rounded-lg bg-(--ui-bg-elevated) flex items-center justify-center text-(--ui-text-muted) hover:text-sky-400 disabled:opacity-30 transition-colors"
                 :disabled="savingWater || waterToday >= waterGoal"
                 @click="setWater(Math.round(waterToday) + 1)"
               >
-                <UIcon name="i-heroicons-plus" class="w-3.5 h-3.5" />
+                <AppIcon name="plus" class="w-3.5 h-3.5" />
               </button>
             </div>
           </div>
@@ -422,7 +422,7 @@ onMounted(load)
             :disabled="savingWater"
             @click="setWater(i === Math.round(waterToday) ? i - 1 : i)"
           >
-            <UIcon name="i-heroicons-beaker" class="w-4 h-4" />
+            <AppIcon name="beaker" class="w-4 h-4" />
           </button>
         </div>
 
@@ -440,11 +440,11 @@ onMounted(load)
       <UCard v-if="sleepHabit" :ui="{ root: 'rounded-2xl', body: 'p-4 sm:p-4 space-y-4' }">
         <header class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <UIcon name="i-heroicons-moon" class="w-4 h-4 text-indigo-400" />
+            <AppIcon name="moon" class="w-4 h-4 text-indigo-400" />
             <h3 class="text-xs font-semibold text-(--ui-text-muted) uppercase tracking-wide">Sleep Last Night</h3>
           </div>
           <UButton
-            icon="i-heroicons-pencil-square"
+            :icon="resolveIcon('pencil-square')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -508,7 +508,7 @@ onMounted(load)
       <UCard v-if="mealHabits.length" :ui="{ root: 'rounded-2xl', body: 'p-4 sm:p-4 space-y-3' }">
         <header class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <UIcon name="i-heroicons-scale" class="w-4 h-4 text-amber-400" />
+            <AppIcon name="scale" class="w-4 h-4 text-amber-400" />
             <h3 class="text-xs font-semibold text-(--ui-text-muted) uppercase tracking-wide">Meals</h3>
           </div>
           <p class="text-xs text-(--ui-text-dimmed)">
@@ -526,8 +526,8 @@ onMounted(load)
             <!-- Meal row -->
             <div class="flex items-center justify-between px-3 py-3">
               <div class="flex items-center gap-2">
-                <UIcon
-                  :name="MEAL_ICONS[meal.name] ?? 'i-heroicons-beaker'"
+                <AppIcon
+                  :name="MEAL_ICONS[meal.name] ?? resolveIcon('beaker')"
                   class="w-4 h-4 text-(--ui-text-muted)"
                 />
                 <span class="text-sm font-medium">{{ meal.name }}</span>
@@ -544,7 +544,7 @@ onMounted(load)
                   class="w-7 h-7 rounded-lg bg-(--ui-bg-elevated) flex items-center justify-center text-(--ui-text-muted) hover:text-(--ui-text) transition-colors"
                   @click="openMealLog(meal)"
                 >
-                  <UIcon name="i-heroicons-pencil" class="w-3.5 h-3.5" />
+                  <AppIcon name="pencil" class="w-3.5 h-3.5" />
                 </button>
               </div>
             </div>
@@ -569,7 +569,7 @@ onMounted(load)
     <LogSheet
       :open="showStepsSheet"
       title="Steps"
-      icon="i-heroicons-fire"
+      :icon="resolveIcon('fire')"
       icon-color="#f43f5e"
       :current="stepsSheetValue"
       :target="stepsGoal"
@@ -587,7 +587,7 @@ onMounted(load)
     <LogSheet
       :open="showSleepSheet"
       title="Sleep"
-      icon="i-heroicons-moon"
+      :icon="resolveIcon('moon')"
       icon-color="#818cf8"
       :current="sleepSheetValue"
       :target="sleepGoal"
@@ -605,7 +605,7 @@ onMounted(load)
     <LogSheet
       :open="mealSheetOpen"
       :title="mealSheetHabit?.name ?? 'Meal'"
-      :icon="MEAL_ICONS[mealSheetHabit?.name ?? ''] ?? 'i-heroicons-beaker'"
+      :icon="MEAL_ICONS[mealSheetHabit?.name ?? ''] ?? resolveIcon('beaker')"
       icon-color="#fbbf24"
       :current="mealSheetValue"
       :target="mealSheetHabit?.target_value ?? 0"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -472,7 +472,7 @@ onMounted(async () => {
             Private, offline, and flexible habit tracking. Let's get started.
           </p>
         </div>
-        <UButton to="/habits" size="lg" icon="i-heroicons-plus" class="px-8">
+        <UButton to="/habits" size="lg" :icon="resolveIcon('plus')" class="px-8">
           Create My First Habit
         </UButton>
       </div>
@@ -537,7 +537,7 @@ onMounted(async () => {
             class="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center"
             :style="{ backgroundColor: habit.color + '22' }"
           >
-            <UIcon :name="habit.icon" class="w-5 h-5" :style="{ color: habit.color }" />
+            <AppIcon :name="habit.icon" :color="habit.color" class="w-5 h-5" />
           </div>
 
           <!-- Name + subtitle -->
@@ -606,7 +606,7 @@ onMounted(async () => {
               :disabled="toggling.has(habit.id)"
               @click="toggle(habit)"
             >
-              <UIcon v-if="isHabitDone(habit)" name="i-heroicons-check" class="w-3.5 h-3.5 text-white" />
+              <AppIcon v-if="isHabitDone(habit)" name="check" class="w-3.5 h-3.5 text-white" />
             </button>
           </template>
 
@@ -622,8 +622,8 @@ onMounted(async () => {
                 Log
               </UButton>
               <div v-if="isHabitDone(habit)" class="w-5 flex-shrink-0 flex items-center justify-center">
-                <UIcon
-                  name="i-heroicons-check-circle"
+                <AppIcon
+                  name="check-circle"
                   class="w-5 h-5"
                   :class="habit.type === 'NUMERIC' ? 'text-primary-400' : 'text-amber-400'"
                 />
@@ -670,8 +670,8 @@ onMounted(async () => {
               :aria-label="todoToggledIds.has(todo.id) ? `Mark '${todo.title}' not done` : `Mark '${todo.title}' done`"
               @click="toggleTodoLocal(todo)"
             >
-              <UIcon v-if="todoToggledIds.has(todo.id)" name="i-heroicons-check" class="w-3 h-3 text-white" aria-hidden="true" />
-              <UIcon v-else-if="todo.is_recurring" name="i-heroicons-arrow-path" class="w-2.5 h-2.5 text-(--ui-text-dimmed)" aria-hidden="true" />
+              <AppIcon v-if="todoToggledIds.has(todo.id)" name="check" class="w-3 h-3 text-white" aria-hidden="true" />
+              <AppIcon v-else-if="todo.is_recurring" name="arrow-path" class="w-2.5 h-2.5 text-(--ui-text-dimmed)" aria-hidden="true" />
             </button>
 
             <!-- Title + estimate -->
@@ -681,14 +681,14 @@ onMounted(async () => {
                 :class="todoToggledIds.has(todo.id) ? 'line-through text-(--ui-text-dimmed)' : 'text-(--ui-text)'"
               >{{ todo.title }}</p>
               <p v-if="todo.estimated_minutes" class="text-xs text-(--ui-text-dimmed) flex items-center gap-0.5 mt-0.5">
-                <UIcon name="i-heroicons-clock" class="w-3 h-3" />
+                <AppIcon name="clock" class="w-3 h-3" />
                 {{ todo.estimated_minutes }}m
               </p>
             </div>
           </li>
         </ul>
 
-        <UButton to="/todos" variant="ghost" color="neutral" size="xs" icon="i-heroicons-arrow-right" trailing aria-label="See all todos">
+        <UButton to="/todos" variant="ghost" color="neutral" size="xs" :icon="resolveIcon('arrow-right')" trailing aria-label="See all todos">
           See all
         </UButton>
       </section>
@@ -710,7 +710,7 @@ onMounted(async () => {
               aria-label="Dismiss"
               @click="boredDismissed = true"
             >
-              <UIcon name="i-heroicons-x-mark" class="w-4 h-4" />
+              <AppIcon name="x-mark" class="w-4 h-4" />
             </button>
           </div>
 
@@ -728,11 +728,11 @@ onMounted(async () => {
               <template v-if="settings.theme === 'habitat'">
                 <div class="mini-ball-specular" />
                 <div class="mini-ball-window">
-                  <UIcon
+                  <AppIcon
                     v-if="boredOracleResult && !boredShaking && boredCategory"
                     :name="boredCategory.icon"
+                    :color="boredCategory.color"
                     class="w-3 h-3"
-                    :style="{ color: boredCategory.color }"
                   />
                   <span v-else class="mini-idle-symbol">?</span>
                 </div>
@@ -742,11 +742,11 @@ onMounted(async () => {
               <template v-else-if="settings.theme === 'forest'">
                 <div class="mini-stone-moss" />
                 <div class="mini-stone-face">
-                  <UIcon
+                  <AppIcon
                     v-if="boredOracleResult && !boredShaking && boredCategory"
                     :name="boredCategory.icon"
+                    :color="boredCategory.color"
                     class="w-3 h-3"
-                    :style="{ color: boredCategory.color }"
                   />
                   <span v-else class="mini-idle-symbol rune">ᛟ</span>
                 </div>
@@ -758,11 +758,11 @@ onMounted(async () => {
                 <div class="mini-bubble mini-bubble-1" />
                 <div class="mini-bubble mini-bubble-2" />
                 <div class="mini-bubble mini-bubble-3" />
-                <UIcon
+                <AppIcon
                   v-if="boredOracleResult && !boredShaking && boredCategory"
                   :name="boredCategory.icon"
+                  :color="boredCategory.color"
                   class="w-3 h-3 relative z-10"
-                  :style="{ color: boredCategory.color }"
                 />
                 <span v-else class="mini-idle-symbol ocean relative z-10">✦</span>
               </template>
@@ -781,7 +781,7 @@ onMounted(async () => {
                     class="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium"
                     :style="{ backgroundColor: boredCategory.color + '22', color: boredCategory.color }"
                   >
-                    <UIcon :name="boredCategory.icon" class="w-3 h-3" />
+                    <AppIcon :name="boredCategory.icon" class="w-3 h-3" />
                     {{ boredCategory.name }}
                   </span>
                   <span v-if="boredEstimate" class="text-xs px-2 py-0.5 rounded-full bg-(--ui-bg-elevated) text-(--ui-text-toned)">
@@ -802,7 +802,7 @@ onMounted(async () => {
             variant="soft"
             color="success"
             size="sm"
-            icon="i-heroicons-check"
+            :icon="resolveIcon('check')"
             :loading="boredMarking"
             @click="markBoredDone"
           >
@@ -828,13 +828,13 @@ onMounted(async () => {
             class="flex items-center gap-3 p-3 rounded-xl bg-(--ui-bg-muted) border border-(--ui-border) hover:border-(--ui-border-accented) transition-colors"
           >
             <div class="w-8 h-8 rounded-full bg-primary-500/10 flex-shrink-0 flex items-center justify-center">
-              <UIcon name="i-heroicons-pencil-square" class="w-4 h-4 text-primary-400" />
+              <AppIcon name="pencil-square" class="w-4 h-4 text-primary-400" />
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-sm font-medium text-(--ui-text) truncate">{{ ci.title }}</p>
               <p class="text-xs text-(--ui-text-dimmed)">{{ ci.response_count }} {{ ci.response_count === 1 ? 'response' : 'responses' }}</p>
             </div>
-            <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
+            <AppIcon name="chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
           </NuxtLink>
 
           <!-- Scribbles updated today -->
@@ -844,7 +844,7 @@ onMounted(async () => {
             class="flex items-center gap-3 p-3 rounded-xl bg-(--ui-bg-muted) border border-(--ui-border) hover:border-(--ui-border-accented) transition-colors"
           >
             <div class="w-8 h-8 rounded-full bg-amber-500/10 flex-shrink-0 flex items-center justify-center">
-              <UIcon name="i-heroicons-pencil" class="w-4 h-4 text-amber-400" />
+              <AppIcon name="pencil" class="w-4 h-4 text-amber-400" />
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-sm font-medium text-(--ui-text)">Scribbles</p>
@@ -852,7 +852,7 @@ onMounted(async () => {
                 {{ todayScribbles.length }} {{ todayScribbles.length === 1 ? 'note' : 'notes' }} updated today
               </p>
             </div>
-            <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
+            <AppIcon name="chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
           </NuxtLink>
 
           <!-- Voice notes recorded today -->
@@ -862,7 +862,7 @@ onMounted(async () => {
             class="flex items-center gap-3 p-3 rounded-xl bg-(--ui-bg-muted) border border-(--ui-border) hover:border-(--ui-border-accented) transition-colors"
           >
             <div class="w-8 h-8 rounded-full bg-rose-500/10 flex-shrink-0 flex items-center justify-center">
-              <UIcon name="i-heroicons-microphone" class="w-4 h-4 text-rose-400" />
+              <AppIcon name="microphone" class="w-4 h-4 text-rose-400" />
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-sm font-medium text-(--ui-text)">Voice Notes</p>
@@ -870,7 +870,7 @@ onMounted(async () => {
                 {{ todayVoiceCount }} {{ todayVoiceCount === 1 ? 'recording' : 'recordings' }} today
               </p>
             </div>
-            <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
+            <AppIcon name="chevron-right" class="w-4 h-4 text-slate-600 flex-shrink-0" />
           </NuxtLink>
 
         </div>

--- a/app/pages/jots/edit-[id].vue
+++ b/app/pages/jots/edit-[id].vue
@@ -96,7 +96,7 @@ onMounted(load)
       <BackNav to="/jots" label="Jot" />
       <div class="flex items-center gap-2">
         <UButton
-          icon="i-heroicons-trash"
+          :icon="resolveIcon('trash')"
           color="error"
           variant="ghost"
           size="sm"
@@ -162,8 +162,8 @@ onMounted(load)
           class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1.5 transition-colors"
           @click="annotExpanded = !annotExpanded"
         >
-          <UIcon
-            :name="annotExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-tag'"
+          <AppIcon
+            :name="annotExpanded ? 'chevron-down' : 'tag'"
             class="w-3.5 h-3.5"
           />
           <span v-if="annotationCount > 0">{{ annotationCount }} annotation{{ annotationCount !== 1 ? 's' : '' }}</span>
@@ -173,7 +173,7 @@ onMounted(load)
           <div v-for="(val, key) in textForm.annotations" :key="key" class="flex items-center gap-2">
             <span class="text-[11px] text-(--ui-text-dimmed) font-mono shrink-0">{{ key }}</span>
             <span class="text-[11px] text-(--ui-text-muted) flex-1 min-w-0 truncate">{{ val }}</span>
-            <UButton icon="i-heroicons-x-mark" color="neutral" variant="ghost" size="sm" class="text-slate-600 hover:text-red-400 shrink-0" @click="removeAnnot(String(key))" />
+            <UButton :icon="resolveIcon('x-mark')" color="neutral" variant="ghost" size="sm" class="text-slate-600 hover:text-red-400 shrink-0" @click="removeAnnot(String(key))" />
           </div>
           <div class="flex items-center gap-1.5">
             <UInput v-model="newAnnotKey" placeholder="key" size="xs" variant="outline" class="flex-1" @keydown.enter="commitAnnot" />

--- a/app/pages/jots/index.vue
+++ b/app/pages/jots/index.vue
@@ -159,14 +159,14 @@ onUnmounted(() => {
       <div class="flex items-center gap-1.5">
         <UButton
           v-if="timeline.length > 0"
-          :icon="gridView ? 'i-heroicons-list-bullet' : 'i-heroicons-squares-2x2'"
+          :icon="resolveIcon(gridView ? 'list-bullet' : 'squares-2x2')"
           size="sm"
           color="neutral"
           variant="ghost"
           :aria-label="gridView ? 'Switch to list view' : 'Switch to grid view'"
           @click="gridView = !gridView"
         />
-        <UButton icon="i-heroicons-plus" size="sm" @click="showPickSheet = true">New</UButton>
+        <UButton :icon="resolveIcon('plus')" size="sm" @click="showPickSheet = true">New</UButton>
       </div>
     </header>
 
@@ -176,8 +176,8 @@ onUnmounted(() => {
       :title="errorMsg"
       color="error"
       variant="soft"
-      icon="i-heroicons-exclamation-circle"
-      :close-button="{ icon: 'i-heroicons-x-mark', color: 'error', variant: 'ghost', size: 'sm' }"
+      :icon="resolveIcon('exclamation-circle')"
+      :close-button="{ icon: resolveIcon('x-mark'), color: 'error', variant: 'ghost', size: 'sm' }"
       @close="errorMsg = null"
     />
 
@@ -202,7 +202,7 @@ onUnmounted(() => {
         >
           <div class="flex items-start gap-2.5">
             <div class="w-6 h-6 rounded-full bg-amber-500/10 flex items-center justify-center mt-0.5 shrink-0">
-              <UIcon name="i-heroicons-pencil" class="w-3.5 h-3.5 text-amber-400" />
+              <AppIcon name="pencil" class="w-3.5 h-3.5 text-amber-400" />
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-start justify-between gap-2">
@@ -229,7 +229,7 @@ onUnmounted(() => {
               :title="hasLinkedTodo(item.data.id) ? 'View linked TODO' : 'Create TODO for this jot'"
               @click.stop="onJotLinkClick(item)"
             >
-              <UIcon :name="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'" class="w-3.5 h-3.5" />
+              <AppIcon :name="hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link'" class="w-3.5 h-3.5" />
             </button>
           </div>
         </li>
@@ -241,10 +241,10 @@ onUnmounted(() => {
         >
           <div class="flex items-center gap-3">
             <div class="w-6 h-6 rounded-full bg-rose-500/10 flex items-center justify-center shrink-0">
-              <UIcon name="i-heroicons-microphone" class="w-3.5 h-3.5 text-rose-400" />
+              <AppIcon name="microphone" class="w-3.5 h-3.5 text-rose-400" />
             </div>
             <UButton
-              :icon="currentlyPlaying === item.data.id ? 'i-heroicons-pause' : 'i-heroicons-play'"
+              :icon="resolveIcon(currentlyPlaying === item.data.id ? 'pause' : 'play')"
               :color="currentlyPlaying === item.data.id ? 'primary' : 'neutral'"
               :variant="currentlyPlaying === item.data.id ? 'soft' : 'outline'"
               size="sm"
@@ -256,7 +256,7 @@ onUnmounted(() => {
               <p class="text-xs type-duration text-(--ui-text-dimmed)">{{ fmtDuration((item.data as VoiceNote).duration) }}</p>
             </div>
             <UButton
-              :icon="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'"
+              :icon="resolveIcon(hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link')"
               color="neutral"
               variant="ghost"
               size="sm"
@@ -264,7 +264,7 @@ onUnmounted(() => {
               @click="onJotLinkClick(item)"
             />
             <UButton
-              icon="i-heroicons-trash"
+              :icon="resolveIcon('trash')"
               color="neutral"
               variant="ghost"
               size="sm"
@@ -281,7 +281,7 @@ onUnmounted(() => {
         >
           <div class="flex items-center gap-3">
             <div class="w-6 h-6 rounded-full bg-sky-500/10 flex items-center justify-center shrink-0">
-              <UIcon name="i-heroicons-photo" class="w-3.5 h-3.5 text-sky-400" />
+              <AppIcon name="photo" class="w-3.5 h-3.5 text-sky-400" />
             </div>
             <img
               v-if="(item.data as ImageNote).url"
@@ -294,7 +294,7 @@ onUnmounted(() => {
               <p class="text-xs text-(--ui-text-dimmed)">{{ fmtDate(item.data.created_at, appSettings.use24HourTime) }}</p>
             </div>
             <UButton
-              :icon="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'"
+              :icon="resolveIcon(hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link')"
               color="neutral"
               variant="ghost"
               size="sm"
@@ -302,7 +302,7 @@ onUnmounted(() => {
               @click="onJotLinkClick(item)"
             />
             <UButton
-              icon="i-heroicons-trash"
+              :icon="resolveIcon('trash')"
               color="neutral"
               variant="ghost"
               size="sm"
@@ -345,7 +345,7 @@ onUnmounted(() => {
                     :class="hasLinkedTodo(item.data.id) ? 'text-primary-400' : 'text-slate-600 hover:text-primary-400'"
                     @click.stop="onJotLinkClick(item)"
                   >
-                    <UIcon :name="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'" class="w-3 h-3" />
+                    <AppIcon :name="hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link'" class="w-3 h-3" />
                   </button>
                   <span class="text-[10px] text-slate-600">{{ timeAgo(item.data.updated_at) }}</span>
                 </div>
@@ -362,14 +362,14 @@ onUnmounted(() => {
           <div class="h-0.5 bg-gradient-to-r from-rose-500/70 to-rose-600/30" />
           <div class="p-3 flex flex-col items-center gap-2.5 text-center">
             <div class="w-12 h-12 rounded-2xl bg-rose-500/10 border border-rose-500/20 flex items-center justify-center mt-1">
-              <UIcon name="i-heroicons-microphone" class="w-6 h-6 text-rose-400" />
+              <AppIcon name="microphone" class="w-6 h-6 text-rose-400" />
             </div>
             <div>
               <p class="text-sm type-duration font-medium text-(--ui-text-toned)">{{ fmtDuration((item.data as VoiceNote).duration) }}</p>
               <p class="text-[10px] text-slate-600 mt-0.5">{{ timeAgo(item.data.created_at) }}</p>
             </div>
             <UButton
-              :icon="currentlyPlaying === item.data.id ? 'i-heroicons-pause' : 'i-heroicons-play'"
+              :icon="resolveIcon(currentlyPlaying === item.data.id ? 'pause' : 'play')"
               :color="currentlyPlaying === item.data.id ? 'primary' : 'neutral'"
               :variant="currentlyPlaying === item.data.id ? 'soft' : 'outline'"
               size="xs"
@@ -378,7 +378,7 @@ onUnmounted(() => {
             />
             <div class="flex items-center gap-0.5 pb-1">
               <UButton
-                :icon="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'"
+                :icon="resolveIcon(hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link')"
                 color="neutral"
                 variant="ghost"
                 size="xs"
@@ -386,7 +386,7 @@ onUnmounted(() => {
                 @click.stop="onJotLinkClick(item)"
               />
               <UButton
-                icon="i-heroicons-trash"
+                :icon="resolveIcon('trash')"
                 color="neutral"
                 variant="ghost"
                 size="xs"
@@ -409,7 +409,7 @@ onUnmounted(() => {
             class="w-full object-cover rounded-t-2xl"
           />
           <div v-else class="w-full aspect-[4/3] bg-(--ui-bg-elevated) flex items-center justify-center rounded-t-2xl">
-            <UIcon name="i-heroicons-photo" class="w-8 h-8 text-slate-600" />
+            <AppIcon name="photo" class="w-8 h-8 text-slate-600" />
           </div>
           <div class="px-2.5 py-2 flex items-center justify-between gap-1">
             <div class="min-w-0">
@@ -422,10 +422,10 @@ onUnmounted(() => {
                 :class="hasLinkedTodo(item.data.id) ? 'text-primary-400' : 'text-slate-600 hover:text-primary-400'"
                 @click="onJotLinkClick(item)"
               >
-                <UIcon :name="hasLinkedTodo(item.data.id) ? 'i-heroicons-paper-clip' : 'i-heroicons-link'" class="w-3 h-3" />
+                <AppIcon :name="hasLinkedTodo(item.data.id) ? 'paper-clip' : 'link'" class="w-3 h-3" />
               </button>
               <UButton
-                icon="i-heroicons-trash"
+                :icon="resolveIcon('trash')"
                 color="neutral"
                 variant="ghost"
                 size="xs"
@@ -479,7 +479,7 @@ onUnmounted(() => {
         <div class="h-full overflow-y-auto p-5 space-y-5">
           <div class="flex items-center justify-between">
             <h3 class="text-base font-semibold">New Jot</h3>
-            <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" aria-label="Close" @click="showPickSheet = false" />
+            <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" aria-label="Close" @click="showPickSheet = false" />
           </div>
           <div class="flex flex-col items-center justify-center pt-8">
             <JotsRing class="hidden sm:flex" @select="onRingSelect" />

--- a/app/pages/jots/new.vue
+++ b/app/pages/jots/new.vue
@@ -107,8 +107,8 @@ async function save() {
           class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1.5 transition-colors"
           @click="annotExpanded = !annotExpanded"
         >
-          <UIcon
-            :name="annotExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-tag'"
+          <AppIcon
+            :name="annotExpanded ? 'chevron-down' : 'tag'"
             class="w-3.5 h-3.5"
           />
           <span v-if="annotationCount > 0">{{ annotationCount }} annotation{{ annotationCount !== 1 ? 's' : '' }}</span>
@@ -118,7 +118,7 @@ async function save() {
           <div v-for="(val, key) in textForm.annotations" :key="key" class="flex items-center gap-2">
             <span class="text-[11px] text-(--ui-text-dimmed) font-mono shrink-0">{{ key }}</span>
             <span class="text-[11px] text-(--ui-text-muted) flex-1 min-w-0 truncate">{{ val }}</span>
-            <UButton icon="i-heroicons-x-mark" color="neutral" variant="ghost" size="sm" class="text-slate-600 hover:text-red-400 shrink-0" @click="removeAnnot(String(key))" />
+            <UButton :icon="resolveIcon('x-mark')" color="neutral" variant="ghost" size="sm" class="text-slate-600 hover:text-red-400 shrink-0" @click="removeAnnot(String(key))" />
           </div>
           <div class="flex items-center gap-1.5">
             <UInput v-model="newAnnotKey" placeholder="key" size="xs" variant="outline" class="flex-1" @keydown.enter="commitAnnot" />

--- a/app/pages/matrix.vue
+++ b/app/pages/matrix.vue
@@ -217,7 +217,7 @@ onMounted(() => {
       v-if="!loading && habits.length === 0"
       class="flex flex-col items-center justify-center gap-4 py-8 text-center"
     >
-      <UIcon name="i-heroicons-table-cells" class="w-10 h-10 text-(--ui-text-dimmed) opacity-30" />
+      <AppIcon name="table-cells" class="w-10 h-10 text-(--ui-text-dimmed) opacity-30" />
       <div class="space-y-1">
         <p class="font-semibold text-(--ui-text)">No habits to display</p>
         <p class="text-sm text-(--ui-text-dimmed) max-w-xs">Create habits to see your completion history in this grid view.</p>
@@ -257,7 +257,7 @@ onMounted(() => {
               class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center"
               :style="{ backgroundColor: habit.color + '33' }"
             >
-              <UIcon :name="habit.icon" class="w-3.5 h-3.5" :style="{ color: habit.color }" />
+              <AppIcon :name="habit.icon" :color="habit.color" class="w-3.5 h-3.5" />
             </div>
             <span class="text-xs font-medium text-(--ui-text) truncate">{{ habit.name }}</span>
           </div>
@@ -278,7 +278,7 @@ onMounted(() => {
               :disabled="toggling.has(`${habit.id}:${date}`)"
               @click="toggle(habit, date)"
             >
-              <UIcon v-if="isDone(habit, date)" name="i-heroicons-check" class="w-3.5 h-3.5 text-white" />
+              <AppIcon v-if="isDone(habit, date)" name="check" class="w-3.5 h-3.5 text-white" />
             </button>
 
             <!-- NUMERIC / LIMIT -->
@@ -333,7 +333,7 @@ onMounted(() => {
             class="w-7 h-7 rounded-full shrink-0 flex items-center justify-center"
             :style="{ backgroundColor: cellEdit.habit.color + '33' }"
           >
-            <UIcon :name="cellEdit.habit.icon" class="w-4 h-4" :style="{ color: cellEdit.habit.color }" />
+            <AppIcon :name="cellEdit.habit.icon" :color="cellEdit.habit.color" class="w-4 h-4" />
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold text-(--ui-text) truncate">{{ cellEdit.habit.name }}</p>
@@ -346,7 +346,7 @@ onMounted(() => {
             </p>
           </div>
           <button class="p-2 text-(--ui-text-dimmed) hover:text-(--ui-text-toned) transition-colors" @click="cellEdit = null">
-            <UIcon name="i-heroicons-x-mark" class="w-5 h-5" />
+            <AppIcon name="x-mark" class="w-5 h-5" />
           </button>
         </div>
 
@@ -371,7 +371,7 @@ onMounted(() => {
             :disabled="savingCell"
             @click="saveCell"
           >
-            <UIcon name="i-heroicons-check" class="w-5 h-5 text-white" />
+            <AppIcon name="check" class="w-5 h-5 text-white" />
           </button>
         </div>
 

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -2,12 +2,12 @@
 const route = useRoute()
 
 const SETTINGS_SECTIONS = [
-  { to: '/settings/display', label: 'Display', icon: 'i-heroicons-swatch' },
-  { to: '/settings/features', label: 'Features', icon: 'i-heroicons-squares-2x2' },
-  { to: '/settings/notifications', label: 'Notifications', icon: 'i-heroicons-bell' },
-  { to: '/settings/permissions', label: 'Permissions', icon: 'i-heroicons-shield-check' },
-  { to: '/settings/data', label: 'Data', icon: 'i-heroicons-circle-stack' },
-  { to: '/settings/more', label: 'More', icon: 'i-heroicons-ellipsis-horizontal-circle' },
+  { to: '/settings/display', label: 'Display', icon: resolveIcon('swatch') },
+  { to: '/settings/features', label: 'Features', icon: resolveIcon('squares-2x2') },
+  { to: '/settings/notifications', label: 'Notifications', icon: resolveIcon('bell') },
+  { to: '/settings/permissions', label: 'Permissions', icon: resolveIcon('shield-check') },
+  { to: '/settings/data', label: 'Data', icon: resolveIcon('circle-stack') },
+  { to: '/settings/more', label: 'More', icon: resolveIcon('ellipsis-horizontal-circle') },
 ]
 </script>
 
@@ -27,7 +27,7 @@ const SETTINGS_SECTIONS = [
             ? 'bg-(--ui-bg-elevated) text-(--ui-text)'
             : 'text-(--ui-text-muted) hover:text-(--ui-text-toned) hover:bg-(--ui-bg-muted)'"
         >
-          <UIcon :name="s.icon" class="w-4 h-4 shrink-0" />
+          <AppIcon :name="s.icon" class="w-4 h-4 shrink-0" />
           {{ s.label }}
         </NuxtLink>
         <p class="mt-4 px-3 text-[11px] text-(--ui-text-dimmed) leading-relaxed">

--- a/app/pages/settings/data.vue
+++ b/app/pages/settings/data.vue
@@ -474,7 +474,7 @@ async function nukeOpfs(reload: boolean) {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">Data</h2>
     </header>
@@ -489,7 +489,7 @@ async function nukeOpfs(reload: boolean) {
             <p class="text-xs text-(--ui-text-dimmed)">Download selected data as a versioned JSON file.</p>
           </div>
           <UButton
-            icon="i-heroicons-arrow-down-tray"
+            :icon="resolveIcon('arrow-down-tray')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -504,7 +504,7 @@ async function nukeOpfs(reload: boolean) {
           </div>
           <input ref="importInput" type="file" accept=".json" class="hidden" @change="onImportFileSelected" />
           <UButton
-            icon="i-heroicons-arrow-up-tray"
+            :icon="resolveIcon('arrow-up-tray')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -518,7 +518,7 @@ async function nukeOpfs(reload: boolean) {
             <p class="text-xs text-(--ui-text-dimmed)">Download the raw <span class="font-mono">.sqlite3</span> database file.</p>
           </div>
           <UButton
-            icon="i-heroicons-circle-stack"
+            :icon="resolveIcon('circle-stack')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -533,7 +533,7 @@ async function nukeOpfs(reload: boolean) {
             <p class="text-xs text-(--ui-text-dimmed)">Download text notes, voice recordings, and images as a <span class="font-mono">.zip</span>.</p>
           </div>
           <UButton
-            icon="i-heroicons-document-text"
+            :icon="resolveIcon('document-text')"
             variant="ghost"
             color="neutral"
             size="sm"
@@ -555,7 +555,7 @@ async function nukeOpfs(reload: boolean) {
           </div>
           <span class="shrink-0">
             <UButton
-              icon="i-heroicons-trash"
+              :icon="resolveIcon('trash')"
               variant="ghost" color="error" size="sm"
               @click="showClearModal = true"
             />
@@ -569,7 +569,7 @@ async function nukeOpfs(reload: boolean) {
           </div>
           <span class="shrink-0">
             <UButton
-              icon="i-heroicons-fire"
+              :icon="resolveIcon('fire')"
               variant="ghost" color="error" size="sm"
               @click="showNukeModal = true"
             />
@@ -585,7 +585,7 @@ async function nukeOpfs(reload: boolean) {
         <div class="p-5 space-y-4">
           <div class="flex items-center justify-between">
             <h3 class="font-semibold text-(--ui-text)">Export data</h3>
-            <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showExportModal = false" />
+            <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showExportModal = false" />
           </div>
 
           <label class="flex items-center gap-2.5 cursor-pointer">
@@ -621,7 +621,7 @@ async function nukeOpfs(reload: boolean) {
               :key="err"
               class="text-xs text-red-400 flex items-center gap-1.5"
             >
-              <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 shrink-0" />
+              <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 shrink-0" />
               {{ err }}
             </li>
           </ul>
@@ -630,7 +630,7 @@ async function nukeOpfs(reload: boolean) {
             <UButton variant="ghost" color="neutral" size="sm" @click="showExportModal = false">Cancel</UButton>
             <UButton
               size="sm"
-              icon="i-heroicons-arrow-down-tray"
+              :icon="resolveIcon('arrow-down-tray')"
               :loading="exporting"
               :disabled="exportNoneSelected"
               @click="downloadJson"
@@ -648,7 +648,7 @@ async function nukeOpfs(reload: boolean) {
         <div class="p-5 space-y-4">
           <div class="flex items-center justify-between">
             <h3 class="font-semibold text-(--ui-text)">Export Jots</h3>
-            <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showJotsExportModal = false" />
+            <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showJotsExportModal = false" />
           </div>
 
           <p class="text-sm text-(--ui-text-muted)">Choose which types to include. All selected types are bundled into a single <span class="font-mono">.zip</span>.</p>
@@ -680,7 +680,7 @@ async function nukeOpfs(reload: boolean) {
           <div class="flex gap-2 pt-1">
             <UButton
               class="flex-1"
-              icon="i-heroicons-arrow-down-tray"
+              :icon="resolveIcon('arrow-down-tray')"
               :loading="exportingJots"
               :disabled="!jotsExportSel.text && !jotsExportSel.voice && !jotsExportSel.images"
               @click="exportJotsZip"
@@ -699,7 +699,7 @@ async function nukeOpfs(reload: boolean) {
         <div v-if="importError" class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-exclamation-circle" class="w-5 h-5 text-red-400" />
+              <AppIcon name="exclamation-circle" class="w-5 h-5 text-red-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Cannot import</p>
@@ -714,7 +714,7 @@ async function nukeOpfs(reload: boolean) {
         <div v-else-if="importDone" class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-green-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-check-circle" class="w-5 h-5 text-green-400" />
+              <AppIcon name="check-circle" class="w-5 h-5 text-green-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Import complete</p>
@@ -729,7 +729,7 @@ async function nukeOpfs(reload: boolean) {
         <div v-else-if="importPreview" class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-primary-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-arrow-up-tray" class="w-5 h-5 text-primary-400" />
+              <AppIcon name="arrow-up-tray" class="w-5 h-5 text-primary-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Import data?</p>
@@ -768,7 +768,7 @@ async function nukeOpfs(reload: boolean) {
         <div class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-exclamation-triangle" class="w-5 h-5 text-red-400" />
+              <AppIcon name="exclamation-triangle" class="w-5 h-5 text-red-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Clear app data?</p>
@@ -815,7 +815,7 @@ async function nukeOpfs(reload: boolean) {
         <div v-if="wiped" class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-green-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-check-circle" class="w-5 h-5 text-green-400" />
+              <AppIcon name="check-circle" class="w-5 h-5 text-green-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">All data wiped</p>
@@ -827,7 +827,7 @@ async function nukeOpfs(reload: boolean) {
         <div v-else class="p-5 space-y-4">
           <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
-              <UIcon name="i-heroicons-fire" class="w-5 h-5 text-red-400" />
+              <AppIcon name="fire" class="w-5 h-5 text-red-400" />
             </div>
             <div class="space-y-1">
               <p class="font-semibold">Wipe OPFS storage?</p>

--- a/app/pages/settings/display.vue
+++ b/app/pages/settings/display.vue
@@ -70,7 +70,7 @@ function resetTabOrder() {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">Display</h2>
     </header>
@@ -237,10 +237,10 @@ function resetTabOrder() {
               aria-label="Drag to reorder"
               @pointerdown="(e: PointerEvent) => tabOrderContainerRef && onPointerDown(index, e, tabOrderContainerRef)"
             >
-              <UIcon name="i-heroicons-bars-3" class="w-4 h-4" />
+              <AppIcon name="bars-3" class="w-4 h-4" />
             </button>
             <!-- Tab icon + label -->
-            <UIcon :name="item.icon" class="w-5 h-5 text-(--ui-text-muted)" />
+            <AppIcon :name="item.icon" class="w-5 h-5 text-(--ui-text-muted)" />
             <span class="text-sm font-medium">{{ item.label }}</span>
           </div>
         </div>

--- a/app/pages/settings/features.vue
+++ b/app/pages/settings/features.vue
@@ -50,7 +50,7 @@ async function confirmHealthSetup() {
         type: 'NUMERIC',
         target_value: healthSetup.stepGoal,
         color: '#ef4444',
-        icon: 'i-heroicons-fire',
+        icon: resolveIcon('fire'),
         tags: ['habitat-health', 'habitat-steps'],
       })
     }
@@ -63,7 +63,7 @@ async function confirmHealthSetup() {
           type: 'LIMIT',
           target_value: meal.calories,
           color: '#f59e0b',
-          icon: 'i-heroicons-sparkles',
+          icon: resolveIcon('sparkles'),
           tags: ['habitat-health', 'habitat-meals'],
         })
       }
@@ -75,7 +75,7 @@ async function confirmHealthSetup() {
         type: 'NUMERIC',
         target_value: healthSetup.waterGoal,
         color: '#0ea5e9',
-        icon: 'i-heroicons-beaker',
+        icon: resolveIcon('beaker'),
         tags: ['habitat-health', 'habitat-water'],
       })
     }
@@ -86,7 +86,7 @@ async function confirmHealthSetup() {
         type: 'NUMERIC',
         target_value: healthSetup.sleepGoal,
         color: '#6366f1',
-        icon: 'i-heroicons-moon',
+        icon: resolveIcon('moon'),
         tags: ['habitat-health', 'habitat-sleep'],
       })
     }
@@ -101,7 +101,7 @@ async function confirmHealthSetup() {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">Features</h2>
     </header>
@@ -320,11 +320,11 @@ async function confirmHealthSetup() {
                 />
                 <span class="text-xs text-(--ui-text-dimmed) shrink-0">kcal</span>
                 <button class="text-slate-700 hover:text-red-400 transition-colors shrink-0" @click="removeMeal(i)">
-                  <UIcon name="i-heroicons-x-mark" class="w-4 h-4" />
+                  <AppIcon name="x-mark" class="w-4 h-4" />
                 </button>
               </div>
               <button class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1 mt-1" @click="addMeal">
-                <UIcon name="i-heroicons-plus" class="w-3 h-3" /> Add meal
+                <AppIcon name="plus" class="w-3 h-3" /> Add meal
               </button>
             </div>
           </div>

--- a/app/pages/settings/index.vue
+++ b/app/pages/settings/index.vue
@@ -3,37 +3,37 @@ const SETTINGS_SECTIONS = [
   {
     to: '/settings/display',
     label: 'Display',
-    icon: 'i-heroicons-swatch',
+    icon: resolveIcon('swatch'),
     description: 'Theme, color mode, layout options',
   },
   {
     to: '/settings/features',
     label: 'Features',
-    icon: 'i-heroicons-squares-2x2',
+    icon: resolveIcon('squares-2x2'),
     description: 'Feature flags and Pomodoro config',
   },
   {
     to: '/settings/notifications',
     label: 'Notifications',
-    icon: 'i-heroicons-bell',
+    icon: resolveIcon('bell'),
     description: 'Reminders, test notification, log',
   },
   {
     to: '/settings/permissions',
     label: 'Permissions',
-    icon: 'i-heroicons-shield-check',
+    icon: resolveIcon('shield-check'),
     description: 'Install, media, battery, storage',
   },
   {
     to: '/settings/data',
     label: 'Data',
-    icon: 'i-heroicons-circle-stack',
+    icon: resolveIcon('circle-stack'),
     description: 'Export, import, and clear data',
   },
   {
     to: '/settings/more',
     label: 'More',
-    icon: 'i-heroicons-ellipsis-horizontal-circle',
+    icon: resolveIcon('ellipsis-horizontal-circle'),
     description: 'About, diagnostics, danger zone',
   },
 ]
@@ -65,7 +65,7 @@ onMounted(() => {
     <UInput
       v-model="search"
       placeholder="Search settings…"
-      icon="i-heroicons-magnifying-glass"
+      :icon="resolveIcon('magnifying-glass')"
       class="sm:hidden"
     />
 
@@ -77,13 +77,13 @@ onMounted(() => {
         class="flex items-center gap-3 px-4 py-3.5 rounded-2xl bg-(--ui-bg-elevated) hover:bg-(--ui-bg-accented) transition-colors"
       >
         <div class="w-9 h-9 rounded-xl bg-(--ui-bg) flex items-center justify-center shrink-0">
-          <UIcon :name="s.icon" class="w-4.5 h-4.5 text-(--ui-text-muted)" />
+          <AppIcon :name="s.icon" class="w-4.5 h-4.5 text-(--ui-text-muted)" />
         </div>
         <div class="flex-1 min-w-0">
           <p class="text-sm font-medium text-(--ui-text)">{{ s.label }}</p>
           <p class="text-xs text-(--ui-text-dimmed) truncate">{{ s.description }}</p>
         </div>
-        <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
+        <AppIcon name="chevron-right" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
       </NuxtLink>
     </nav>
 

--- a/app/pages/settings/more.vue
+++ b/app/pages/settings/more.vue
@@ -222,7 +222,7 @@ async function forceReload() {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">More</h2>
     </header>
@@ -231,7 +231,7 @@ async function forceReload() {
     <section class="space-y-2">
       <button class="w-full flex items-center justify-between px-1 py-0.5" @click="aboutOpen = !aboutOpen">
         <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed)">About</p>
-        <UIcon :name="aboutOpen ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'" class="w-3.5 h-3.5 text-slate-600" />
+        <AppIcon :name="aboutOpen ? 'chevron-up' : 'chevron-down'" class="w-3.5 h-3.5 text-slate-600" />
       </button>
       <UCard v-if="aboutOpen" :ui="{ root: 'rounded-2xl', body: 'p-0 sm:p-0 divide-y divide-slate-800' }">
 
@@ -265,7 +265,7 @@ async function forceReload() {
         </div>
         <button class="w-full flex items-center justify-between px-4 py-3.5 text-left" @click="openLicenses">
           <p class="text-sm text-(--ui-text-muted)">Open source licenses</p>
-          <UIcon name="i-heroicons-chevron-right" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
+          <AppIcon name="chevron-right" class="w-4 h-4 text-(--ui-text-dimmed) shrink-0" />
         </button>
 
         <!-- DB schema -->
@@ -276,12 +276,12 @@ async function forceReload() {
             </div>
             <div class="flex items-center gap-2 shrink-0">
               <UBadge v-if="dbInfo" :label="`v${dbInfo.userVersion}`" variant="subtle" color="neutral" size="sm" class="font-mono rounded-full" />
-              <UIcon :name="dbInfoOpen ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-4 h-4 text-(--ui-text-dimmed)" />
+              <AppIcon :name="dbInfoOpen ? 'chevron-down' : 'chevron-right'" class="w-4 h-4 text-(--ui-text-dimmed)" />
             </div>
           </button>
           <div v-if="dbInfoOpen" class="border-t border-(--ui-border) px-4 py-3 space-y-2">
             <div v-if="dbInfoLoading" class="flex items-center gap-2 text-xs text-(--ui-text-dimmed)">
-              <UIcon name="i-heroicons-arrow-path" class="w-3.5 h-3.5 animate-spin" /> Loading…
+              <AppIcon name="arrow-path" class="w-3.5 h-3.5 animate-spin" /> Loading…
             </div>
             <template v-else-if="dbInfo">
               <div class="flex items-center gap-2 mb-3">
@@ -294,7 +294,7 @@ async function forceReload() {
                   @click="expandedTable = expandedTable === table.name ? null : table.name"
                 >
                   <span class="text-xs font-mono text-(--ui-text-toned)">{{ table.name }}</span>
-                  <UIcon :name="expandedTable === table.name ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5 text-slate-600" />
+                  <AppIcon :name="expandedTable === table.name ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5 text-slate-600" />
                 </button>
                 <pre v-if="expandedTable === table.name" class="text-[10px] leading-relaxed font-mono text-(--ui-text-muted) bg-(--ui-bg) px-3 py-2 overflow-x-auto border-t border-(--ui-border)">{{ table.sql }}</pre>
               </div>
@@ -309,7 +309,7 @@ async function forceReload() {
                       <span class="text-xs font-mono text-(--ui-text-muted)">{{ idx.name }}</span>
                       <span class="text-[10px] text-slate-600 ml-2">on {{ idx.tbl_name }}</span>
                     </div>
-                    <UIcon :name="expandedTable === idx.name ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5 text-slate-600 shrink-0" />
+                    <AppIcon :name="expandedTable === idx.name ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5 text-slate-600 shrink-0" />
                   </button>
                   <pre v-if="expandedTable === idx.name" class="text-[10px] leading-relaxed font-mono text-(--ui-text-muted) bg-(--ui-bg) px-3 py-2 overflow-x-auto border-t border-(--ui-border)">{{ idx.sql }}</pre>
                 </div>
@@ -325,7 +325,7 @@ async function forceReload() {
     <section class="space-y-2">
       <button class="w-full flex items-center justify-between px-1 py-0.5" @click="diagOpen = !diagOpen">
         <p class="text-xs font-semibold uppercase tracking-wider text-(--ui-text-dimmed)">Diagnostics</p>
-        <UIcon :name="diagOpen ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'" class="w-3.5 h-3.5 text-slate-600" />
+        <AppIcon :name="diagOpen ? 'chevron-up' : 'chevron-down'" class="w-3.5 h-3.5 text-slate-600" />
       </button>
       <UCard v-if="diagOpen" :ui="{ root: 'rounded-2xl', body: 'p-0 sm:p-0 divide-y divide-slate-800' }">
 
@@ -336,7 +336,7 @@ async function forceReload() {
             <p class="text-xs text-(--ui-text-dimmed)">Runs SQLite <span class="font-mono">PRAGMA integrity_check</span></p>
             <div v-if="integrityResults !== null" class="mt-1.5">
               <p v-if="integrityOk" class="text-xs text-green-400 flex items-center gap-1">
-                <UIcon name="i-heroicons-check-circle" class="w-3.5 h-3.5 shrink-0" /> ok
+                <AppIcon name="check-circle" class="w-3.5 h-3.5 shrink-0" /> ok
               </p>
               <ul v-else class="space-y-0.5">
                 <li v-for="(msg, i) in integrityResults" :key="i" class="text-xs text-red-400 font-mono break-all">{{ msg }}</li>
@@ -347,7 +347,7 @@ async function forceReload() {
             <UButton
               size="sm" variant="ghost" color="neutral"
               :loading="integrityLoading"
-              icon="i-heroicons-shield-check"
+              :icon="resolveIcon('shield-check')"
               @click="runIntegrityCheck"
             />
           </span>
@@ -366,7 +366,7 @@ async function forceReload() {
           >
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-bell"
+              :icon="resolveIcon('bell')"
               :disabled="notifPermission !== 'granted'"
               @click="sendTestNotification"
             />
@@ -386,7 +386,7 @@ async function forceReload() {
           >
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-clock"
+              :icon="resolveIcon('clock')"
               :disabled="notifPermission !== 'granted' || !isNativeApp"
               @click="testScheduleOn"
             />
@@ -431,7 +431,7 @@ async function forceReload() {
             </div>
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-arrow-path"
+              :icon="resolveIcon('arrow-path')"
               :loading="pendingNotifsLoading"
               aria-label="Refresh scheduled notifications"
               @click="refreshPendingNotifs"
@@ -443,7 +443,7 @@ async function forceReload() {
               :key="i"
               class="flex items-center gap-3 py-2"
             >
-              <UIcon name="i-heroicons-bell" class="w-3.5 h-3.5 shrink-0 text-(--ui-text-dimmed)" />
+              <AppIcon name="bell" class="w-3.5 h-3.5 shrink-0 text-(--ui-text-dimmed)" />
               <span class="text-xs text-(--ui-text) min-w-0 truncate grow">{{ n.title }}</span>
               <span class="text-xs font-mono text-(--ui-text-muted) shrink-0">{{ n.when }}</span>
             </li>
@@ -458,7 +458,7 @@ async function forceReload() {
                 <p class="text-sm font-medium">Storage</p>
                 <p class="text-xs text-(--ui-text-dimmed)">Browser quota and current usage.</p>
               </div>
-              <UButton size="sm" variant="ghost" color="neutral" icon="i-heroicons-arrow-path" @click="loadStorageEstimate" />
+              <UButton size="sm" variant="ghost" color="neutral" :icon="resolveIcon('arrow-path')" @click="loadStorageEstimate" />
             </div>
             <template v-if="storageEstimate">
               <div class="space-y-1">
@@ -475,8 +475,8 @@ async function forceReload() {
               </div>
               <div class="flex items-center justify-between gap-2">
                 <div class="flex items-center gap-1.5 text-xs">
-                  <UIcon
-                    :name="storagePersisted ? 'i-heroicons-lock-closed' : 'i-heroicons-lock-open'"
+                  <AppIcon
+                    :name="storagePersisted ? 'lock-closed' : 'lock-open'"
                     class="w-3.5 h-3.5"
                     :class="storagePersisted ? 'text-green-400' : 'text-amber-400'"
                   />
@@ -501,12 +501,12 @@ async function forceReload() {
               <p class="text-xs text-(--ui-text-dimmed)">OPFS files</p>
               <div class="flex items-center gap-2 shrink-0">
                 <span v-if="opfsFiles.length > 0" class="text-xs text-(--ui-text-dimmed)">{{ opfsFiles.length }} file{{ opfsFiles.length !== 1 ? 's' : '' }}</span>
-                <UIcon :name="opfsOpen ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5 text-(--ui-text-dimmed)" />
+                <AppIcon :name="opfsOpen ? 'chevron-down' : 'chevron-right'" class="w-3.5 h-3.5 text-(--ui-text-dimmed)" />
               </div>
             </button>
             <div v-if="opfsOpen" class="px-4 pb-3">
               <div v-if="opfsLoading" class="flex items-center gap-2 text-xs text-(--ui-text-dimmed)">
-                <UIcon name="i-heroicons-arrow-path" class="w-3.5 h-3.5 animate-spin" /> Scanning…
+                <AppIcon name="arrow-path" class="w-3.5 h-3.5 animate-spin" /> Scanning…
               </div>
               <div v-else-if="opfsFiles.length === 0" class="text-xs text-(--ui-text-dimmed)">No files found.</div>
               <ul v-else class="space-y-1.5">
@@ -516,7 +516,7 @@ async function forceReload() {
                 </li>
               </ul>
               <button class="mt-3 text-xs text-slate-600 hover:text-(--ui-text-muted) flex items-center gap-1 transition-colors" @click="loadOpfsFiles">
-                <UIcon name="i-heroicons-arrow-path" class="w-3 h-3" /> Refresh
+                <AppIcon name="arrow-path" class="w-3 h-3" /> Refresh
               </button>
             </div>
           </div>
@@ -540,7 +540,7 @@ async function forceReload() {
     <section class="space-y-2">
       <button class="w-full flex items-center justify-between px-1 py-0.5" @click="dragonsOpen = !dragonsOpen">
         <p class="text-xs font-semibold uppercase tracking-wider text-red-900/70">🐉 Here be dragons</p>
-        <UIcon :name="dragonsOpen ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'" class="w-3.5 h-3.5 text-red-900/50" />
+        <AppIcon :name="dragonsOpen ? 'chevron-up' : 'chevron-down'" class="w-3.5 h-3.5 text-red-900/50" />
       </button>
       <UCard v-if="dragonsOpen" :ui="{ root: 'rounded-2xl ring-1 ring-red-900/30', body: 'p-0 sm:p-0 divide-y divide-slate-800' }">
 
@@ -563,7 +563,7 @@ async function forceReload() {
               <UBadge color="warning" variant="subtle" size="xs" class="shrink-0">Active</UBadge>
               <UButton
                 size="sm" variant="ghost" color="neutral"
-                icon="i-heroicons-arrow-path"
+                :icon="resolveIcon('arrow-path')"
                 aria-label="Disable strict CSP and reload"
                 @click="disableStrictCspAndReload"
               />
@@ -585,7 +585,7 @@ async function forceReload() {
           </div>
           <UButton
             size="sm" variant="ghost" color="neutral"
-            icon="i-heroicons-arrow-path" :loading="forceReloading" class="shrink-0"
+            :icon="resolveIcon('arrow-path')" :loading="forceReloading" class="shrink-0"
             @click="forceReload"
           />
         </div>
@@ -599,7 +599,7 @@ async function forceReload() {
         <div class="p-5 space-y-4 flex flex-col max-h-[80vh]">
           <div class="flex items-center justify-between shrink-0">
             <h3 class="font-semibold text-(--ui-text)">Open source licenses</h3>
-            <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showLicensesModal = false" />
+            <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showLicensesModal = false" />
           </div>
           <div v-if="licensesLoading" class="flex items-center justify-center py-8 text-(--ui-text-dimmed) text-sm">
             Loading…

--- a/app/pages/settings/notifications.vue
+++ b/app/pages/settings/notifications.vue
@@ -39,7 +39,7 @@ onMounted(() => {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">Notifications</h2>
     </header>
@@ -51,7 +51,7 @@ onMounted(() => {
         <div class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-bell" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="bell" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Notifications</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Deliver reminders for habits and check-ins.</p>
@@ -103,7 +103,7 @@ onMounted(() => {
           >
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-bell"
+              :icon="resolveIcon('bell')"
               :disabled="notifPermission !== 'granted'"
               @click="sendTestNotification"
             />
@@ -123,7 +123,7 @@ onMounted(() => {
           >
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-clock"
+              :icon="resolveIcon('clock')"
               :disabled="notifPermission !== 'granted' || !isNativeApp"
               @click="testScheduleOn"
             />
@@ -175,7 +175,7 @@ onMounted(() => {
             </div>
             <UButton
               size="sm" variant="ghost" color="neutral"
-              icon="i-heroicons-arrow-path"
+              :icon="resolveIcon('arrow-path')"
               :loading="pendingNotifsLoading"
               aria-label="Refresh scheduled notifications"
               @click="refreshPendingNotifs"
@@ -187,7 +187,7 @@ onMounted(() => {
               :key="i"
               class="flex items-center gap-3 py-2"
             >
-              <UIcon name="i-heroicons-bell" class="w-3.5 h-3.5 shrink-0 text-(--ui-text-dimmed)" />
+              <AppIcon name="bell" class="w-3.5 h-3.5 shrink-0 text-(--ui-text-dimmed)" />
               <span class="text-xs text-(--ui-text) min-w-0 truncate grow">{{ n.title }}</span>
               <span class="text-xs font-mono text-(--ui-text-muted) shrink-0">{{ n.when }}</span>
             </li>

--- a/app/pages/settings/permissions.vue
+++ b/app/pages/settings/permissions.vue
@@ -75,7 +75,7 @@ onMounted(async () => {
   <div class="space-y-6">
     <header class="flex items-center gap-2 mb-4">
       <NuxtLink to="/settings" class="sm:hidden p-1 -ml-1 rounded-lg text-(--ui-text-muted) hover:text-(--ui-text) hover:bg-(--ui-bg-elevated) transition-colors">
-        <UIcon name="i-heroicons-chevron-left" class="w-5 h-5" />
+        <AppIcon name="chevron-left" class="w-5 h-5" />
       </NuxtLink>
       <h2 class="text-xl font-bold">Permissions</h2>
     </header>
@@ -88,7 +88,7 @@ onMounted(async () => {
         <div v-if="isInstalled" class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-arrow-down-tray" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="arrow-down-tray" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Habitat is installed</p>
             </div>
             <p class="text-xs text-green-400">{{ isNativeApp ? 'Running as a native app' : 'Running as a standalone app' }}</p>
@@ -98,7 +98,7 @@ onMounted(async () => {
         <div v-else class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-arrow-down-tray" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="arrow-down-tray" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Install Habitat</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Add to your home screen for offline access and notifications</p>
@@ -107,7 +107,7 @@ onMounted(async () => {
             size="sm"
             variant="soft"
             color="primary"
-            icon="i-heroicons-arrow-down-tray"
+            :icon="resolveIcon('arrow-down-tray')"
             :loading="installing"
             class="shrink-0"
             @click="handleInstall"
@@ -120,7 +120,7 @@ onMounted(async () => {
         <div class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-bell" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="bell" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Notifications</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Deliver reminders for habits and check-ins.</p>
@@ -145,7 +145,7 @@ onMounted(async () => {
         <div v-if="isNativeApp" class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-clock" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="clock" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Exact alarms</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Fire reminders at the exact time you scheduled them.</p>
@@ -177,7 +177,7 @@ onMounted(async () => {
         <div v-if="isNativeApp" class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-battery-100" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="battery-100" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Battery optimization</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Exempt the app so reminders fire even when closed.</p>
@@ -209,8 +209,8 @@ onMounted(async () => {
         <div v-if="!isNativeApp" class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon
-                :name="persistentStorage === 'granted' ? 'i-heroicons-lock-closed' : 'i-heroicons-lock-open'"
+              <AppIcon
+                :name="persistentStorage === 'granted' ? 'lock-closed' : 'lock-open'"
                 class="w-4 h-4 shrink-0"
                 :class="persistentStorage === 'granted' ? 'text-green-400' : 'text-(--ui-text-muted)'"
               />
@@ -252,7 +252,7 @@ onMounted(async () => {
         <div class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-microphone" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="microphone" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Microphone</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Required for voice recordings in Jots.</p>
@@ -269,7 +269,7 @@ onMounted(async () => {
         <div class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-camera" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="camera" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Camera</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Required to capture photos in Jots.</p>
@@ -286,7 +286,7 @@ onMounted(async () => {
         <div v-if="isIos" class="flex items-center justify-between px-4 py-3.5">
           <div class="space-y-0.5 min-w-0">
             <div class="flex items-center gap-2">
-              <UIcon name="i-heroicons-photo" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
+              <AppIcon name="photo" class="w-4 h-4 text-(--ui-text-muted) shrink-0" />
               <p class="text-sm font-medium">Photo library</p>
             </div>
             <p class="text-xs text-(--ui-text-dimmed)">Required to pick existing photos for Jots.</p>
@@ -308,7 +308,7 @@ onMounted(async () => {
         <div class="p-5 space-y-4">
           <div class="flex items-center justify-between">
             <h3 class="font-semibold text-(--ui-text)">Install Habitat</h3>
-            <UButton icon="i-heroicons-x-mark" variant="ghost" color="neutral" size="sm" @click="showInstallModal = false" />
+            <UButton :icon="resolveIcon('x-mark')" variant="ghost" color="neutral" size="sm" @click="showInstallModal = false" />
           </div>
 
           <template v-if="isIosSafari">
@@ -316,7 +316,7 @@ onMounted(async () => {
               <li class="flex items-start gap-3">
                 <span class="text-primary-400 font-semibold shrink-0">1.</span>
                 <span>Tap the <strong class="text-(--ui-text)">Share</strong> button
-                  <UIcon name="i-heroicons-arrow-up-on-square" class="inline w-4 h-4 align-text-bottom text-(--ui-text)" />
+                  <AppIcon name="arrow-up-on-square" class="inline w-4 h-4 align-text-bottom text-(--ui-text)" />
                   in the Safari toolbar</span>
               </li>
               <li class="flex items-start gap-3">

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -393,7 +393,7 @@ onMounted(load)
             class="w-5 h-5 rounded-full flex-shrink-0 flex items-center justify-center"
             :style="{ backgroundColor: item.habit.color + '33' }"
           >
-            <UIcon :name="item.habit.icon" class="w-3 h-3" :style="{ color: item.habit.color }" />
+            <AppIcon :name="item.habit.icon" :color="item.habit.color" class="w-3 h-3" />
           </div>
           <p class="w-20 text-xs text-(--ui-text-muted) truncate flex-shrink-0">{{ item.habit.name }}</p>
           <div class="flex-1 h-1.5 bg-(--ui-bg-elevated) rounded-full overflow-hidden">

--- a/app/pages/todos.vue
+++ b/app/pages/todos.vue
@@ -452,9 +452,9 @@ async function unlinkJot() {
 }
 
 function jotKindIcon(kind: string | undefined): string {
-  if (kind === 'voice') return 'i-heroicons-microphone'
-  if (kind === 'image') return 'i-heroicons-photo'
-  return 'i-heroicons-pencil'
+  if (kind === 'voice') return resolveIcon('microphone')
+  if (kind === 'image') return resolveIcon('photo')
+  return resolveIcon('pencil')
 }
 </script>
 
@@ -471,15 +471,15 @@ function jotKindIcon(kind: string | undefined): string {
             :class="!calendarView ? 'bg-(--ui-bg) text-(--ui-text) shadow-sm' : 'text-(--ui-text-dimmed) hover:text-(--ui-text-toned)'"
             aria-label="List view"
             @click="calendarView = false; selectionChanged()"
-          ><UIcon name="i-heroicons-list-bullet" class="w-4 h-4" /></button>
+          ><AppIcon name="list-bullet" class="w-4 h-4" /></button>
           <button
             class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-md transition-colors"
             :class="calendarView ? 'bg-(--ui-bg) text-(--ui-text) shadow-sm' : 'text-(--ui-text-dimmed) hover:text-(--ui-text-toned)'"
             aria-label="Calendar view"
             @click="calendarView = true; selectionChanged()"
-          ><UIcon name="i-heroicons-calendar-days" class="w-4 h-4" /></button>
+          ><AppIcon name="calendar-days" class="w-4 h-4" /></button>
         </div>
-        <UButton size="sm" class="min-h-[44px]" icon="i-heroicons-plus" @click="openAdd">Add</UButton>
+        <UButton size="sm" class="min-h-[44px]" :icon="resolveIcon('plus')" @click="openAdd">Add</UButton>
       </div>
     </div>
 
@@ -539,8 +539,8 @@ function jotKindIcon(kind: string | undefined): string {
               :class="todo.is_done ? 'border-green-500 bg-green-500' : 'border-(--ui-border-accented) hover:border-(--ui-border-muted)'"
               @click="toggleTodo(todo)"
             >
-              <UIcon v-if="todo.is_done" name="i-heroicons-check" class="w-3.5 h-3.5 text-white" />
-              <UIcon v-else-if="todo.is_recurring" name="i-heroicons-arrow-path" class="w-3 h-3 text-(--ui-text-dimmed)" />
+              <AppIcon v-if="todo.is_done" name="check" class="w-3.5 h-3.5 text-white" />
+              <AppIcon v-else-if="todo.is_recurring" name="arrow-path" class="w-3 h-3 text-(--ui-text-dimmed)" />
             </button>
 
             <!-- Content -->
@@ -557,19 +557,19 @@ function jotKindIcon(kind: string | undefined): string {
                   class="text-xs flex items-center gap-0.5"
                   :class="isOverdue(todo, today) ? 'text-red-400' : 'text-(--ui-text-muted)'"
                 >
-                  <UIcon name="i-heroicons-calendar" class="w-3 h-3" />
+                  <AppIcon name="calendar" class="w-3 h-3" />
                   {{ formatDueDate(todo.due_date, today) }}
                 </time>
                 <span v-if="todo.estimated_minutes" class="text-xs text-(--ui-text-dimmed) flex items-center gap-0.5">
-                  <UIcon name="i-heroicons-clock" class="w-3 h-3" />
+                  <AppIcon name="clock" class="w-3 h-3" />
                   {{ todo.estimated_minutes }}m
                 </span>
                 <span v-if="todo.is_recurring" class="text-xs text-(--ui-text-dimmed) flex items-center gap-0.5">
-                  <UIcon name="i-heroicons-arrow-path" class="w-3 h-3" />
+                  <AppIcon name="arrow-path" class="w-3 h-3" />
                   Repeats {{ todo.recurrence_rule }}
                 </span>
                 <span v-if="todo.show_in_bored" class="text-xs text-amber-500 flex items-center gap-0.5">
-                  <UIcon name="i-heroicons-sparkles" class="w-3 h-3" />
+                  <AppIcon name="sparkles" class="w-3 h-3" />
                   Bored
                 </span>
               </div>
@@ -594,7 +594,7 @@ function jotKindIcon(kind: string | undefined): string {
                     size="xs"
                     variant="ghost"
                     color="neutral"
-                    :icon="timer.isRunning ? 'i-heroicons-pause' : 'i-heroicons-play'"
+                    :icon="resolveIcon(timer.isRunning ? 'pause' : 'play')"
                     :aria-label="timer.isRunning ? 'Pause timer' : 'Resume timer'"
                     @click="timer.isRunning ? timer.pauseTimer() : timer.resumeTimer()"
                   />
@@ -602,7 +602,7 @@ function jotKindIcon(kind: string | undefined): string {
                     size="xs"
                     variant="soft"
                     color="success"
-                    icon="i-heroicons-check"
+                    :icon="resolveIcon('check')"
                     aria-label="Done"
                     @click="finishTimerAndDone(todo)"
                   >Done</UButton>
@@ -610,7 +610,7 @@ function jotKindIcon(kind: string | undefined): string {
                     size="xs"
                     variant="ghost"
                     color="neutral"
-                    icon="i-heroicons-x-mark"
+                    :icon="resolveIcon('x-mark')"
                     aria-label="Stop timer"
                     @click="timer.stopTimer()"
                   />
@@ -624,7 +624,7 @@ function jotKindIcon(kind: string | undefined): string {
                     size="xs"
                     variant="soft"
                     color="neutral"
-                    icon="i-heroicons-play"
+                    :icon="resolveIcon('play')"
                     aria-label="Start timer"
                     @click="handleTodoStart(todo)"
                     @pointerdown="startLongPress(todo)"
@@ -645,17 +645,17 @@ function jotKindIcon(kind: string | undefined): string {
                       class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted) flex items-center gap-2"
                       @click="startMode(todo, 'stopwatch')"
                     >
-                      <UIcon name="i-heroicons-play" class="w-4 h-4" /> Stopwatch
+                      <AppIcon name="play" class="w-4 h-4" /> Stopwatch
                     </button>
                     <div role="menuitem" class="flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-(--ui-bg-muted)">
-                      <UIcon name="i-heroicons-clock" class="w-4 h-4 shrink-0" />
+                      <AppIcon name="clock" class="w-4 h-4 shrink-0" />
                       <div class="flex items-center gap-1" @click.stop>
                         <button
                           class="w-6 h-6 rounded-md bg-(--ui-bg-elevated) border border-(--ui-border) flex items-center justify-center text-(--ui-text-muted) hover:text-(--ui-text) transition-colors active:scale-90"
                           :class="{ 'opacity-30 pointer-events-none': modeMenuMinutes <= 5 }"
                           @click="modeMenuMinutes = Math.max(5, modeMenuMinutes - 5)"
                         >
-                          <UIcon name="i-heroicons-minus" class="w-3 h-3" />
+                          <AppIcon name="minus" class="w-3 h-3" />
                         </button>
                         <span class="w-10 text-center font-semibold tabular-nums text-(--ui-text)">{{ modeMenuMinutes }}</span>
                         <button
@@ -663,7 +663,7 @@ function jotKindIcon(kind: string | undefined): string {
                           :class="{ 'opacity-30 pointer-events-none': modeMenuMinutes >= 120 }"
                           @click="modeMenuMinutes = Math.min(120, modeMenuMinutes + 5)"
                         >
-                          <UIcon name="i-heroicons-plus" class="w-3 h-3" />
+                          <AppIcon name="plus" class="w-3 h-3" />
                         </button>
                       </div>
                       <span class="text-(--ui-text-muted) text-xs">min</span>
@@ -683,8 +683,8 @@ function jotKindIcon(kind: string | undefined): string {
 
             <!-- Actions -->
             <div class="flex flex-col gap-1 shrink-0">
-              <UButton variant="ghost" color="neutral" size="sm" icon="i-heroicons-pencil" class="min-h-[44px]" aria-label="Edit todo" @click="openEdit(todo)" />
-              <UButton variant="ghost" color="neutral" size="sm" icon="i-heroicons-archive-box" class="min-h-[44px]" aria-label="Archive todo" @click="confirmArchiveTodo = todo" />
+              <UButton variant="ghost" color="neutral" size="sm" :icon="resolveIcon('pencil')" class="min-h-[44px]" aria-label="Edit todo" @click="openEdit(todo)" />
+              <UButton variant="ghost" color="neutral" size="sm" :icon="resolveIcon('archive-box')" class="min-h-[44px]" aria-label="Archive todo" @click="confirmArchiveTodo = todo" />
             </div>
           </li>
         </ul>
@@ -693,7 +693,7 @@ function jotKindIcon(kind: string | undefined): string {
 
     <!-- Empty state -->
     <div v-if="filteredSections.length === 0" class="text-center py-12 text-(--ui-text-dimmed)">
-      <UIcon name="i-heroicons-check-circle" class="w-12 h-12 mx-auto mb-3 opacity-30" />
+      <AppIcon name="check-circle" class="w-12 h-12 mx-auto mb-3 opacity-30" />
       <p>No todos yet. Tap + to add one.</p>
     </div>
 
@@ -708,7 +708,7 @@ function jotKindIcon(kind: string | undefined): string {
             <UInput v-model="form.title" placeholder="What needs doing?" class="w-full" autofocus />
           </UFormField>
           <p v-if="titleError" class="text-xs text-red-400 -mt-2 flex items-center gap-1">
-            <UIcon name="i-heroicons-exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
+            <AppIcon name="exclamation-circle" class="w-3.5 h-3.5 flex-shrink-0" />
             {{ titleError }}
           </p>
 
@@ -785,7 +785,7 @@ function jotKindIcon(kind: string | undefined): string {
 
           <!-- Has a linked jot -->
           <div v-if="editingTodo.annotations['linked_jot_id']" class="flex items-center gap-2.5 p-2.5 rounded-xl bg-(--ui-bg-elevated) border border-(--ui-border-accented)">
-            <UIcon
+            <AppIcon
               :name="jotKindIcon(editingTodo.annotations['linked_jot_kind'])"
               class="w-4 h-4 text-(--ui-text-muted) shrink-0"
             />
@@ -793,7 +793,7 @@ function jotKindIcon(kind: string | undefined): string {
               {{ editingTodo.annotations['linked_jot_title'] || editingTodo.annotations['linked_jot_id'] }}
             </span>
             <UButton
-              icon="i-heroicons-arrow-top-right-on-square"
+              :icon="resolveIcon('arrow-top-right-on-square')"
               size="xs"
               variant="ghost"
               color="neutral"
@@ -801,7 +801,7 @@ function jotKindIcon(kind: string | undefined): string {
               @click="showModal = false; navigateTo('/jots')"
             />
             <UButton
-              icon="i-heroicons-x-mark"
+              :icon="resolveIcon('x-mark')"
               size="xs"
               variant="ghost"
               color="error"
@@ -817,7 +817,7 @@ function jotKindIcon(kind: string | undefined): string {
             class="text-xs text-(--ui-text-dimmed) hover:text-(--ui-text-muted) flex items-center gap-1.5 transition-colors py-1"
             @click="openJotPicker"
           >
-            <UIcon name="i-heroicons-link" class="w-3.5 h-3.5" />
+            <AppIcon name="link" class="w-3.5 h-3.5" />
             Link a jot
           </button>
 
@@ -832,7 +832,7 @@ function jotKindIcon(kind: string | undefined): string {
                 class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-(--ui-bg-elevated) transition-colors"
                 @click="selectJot(jot)"
               >
-                <UIcon :name="jotKindIcon(jot.kind)" class="w-3.5 h-3.5 text-(--ui-text-muted) shrink-0" />
+                <AppIcon :name="jotKindIcon(jot.kind)" class="w-3.5 h-3.5 text-(--ui-text-muted) shrink-0" />
                 <span class="text-sm text-(--ui-text-toned) truncate">{{ jot.label }}</span>
               </li>
             </ul>
@@ -846,7 +846,7 @@ function jotKindIcon(kind: string | undefined): string {
             variant="ghost"
             color="error"
             class="flex-none"
-            icon="i-heroicons-trash"
+            :icon="resolveIcon('trash')"
             @click="confirmDeleteTodo = editingTodo"
           />
           <UButton color="primary" class="flex-1" @click="saveTodo">Save</UButton>
@@ -857,7 +857,7 @@ function jotKindIcon(kind: string | undefined): string {
     <!-- Archive confirm -->
     <ConfirmDialog
       :open="!!confirmArchiveTodo"
-      icon="i-heroicons-archive-box"
+      icon="archive-box"
       icon-color="amber"
       :title="`Archive &quot;${confirmArchiveTodo?.title}&quot;?`"
       message="This todo will be moved to your archive."
@@ -871,7 +871,7 @@ function jotKindIcon(kind: string | undefined): string {
     <!-- Delete confirm -->
     <ConfirmDialog
       :open="!!confirmDeleteTodo"
-      icon="i-heroicons-trash"
+      icon="trash"
       icon-color="red"
       :title="`Delete &quot;${confirmDeleteTodo?.title}&quot;?`"
       message="This cannot be undone. The todo will be permanently removed."

--- a/app/pages/welcome.vue
+++ b/app/pages/welcome.vue
@@ -22,25 +22,25 @@ const PROFILES: { id: AppProfile; name: string; description: string; icon: strin
     id: 'minimalist',
     name: 'Minimalist',
     description: 'A pure, distraction-free habit tracker.',
-    icon: 'i-heroicons-sparkles',
+    icon: resolveIcon('sparkles'),
   },
   {
     id: 'journaler',
     name: 'Journaler',
     description: 'Focus on reflection, daily check-ins, and mental wellness.',
-    icon: 'i-heroicons-book-open',
+    icon: resolveIcon('book-open'),
   },
   {
     id: 'productivity',
     name: 'Productivity',
     description: 'Task management, pomodoro timers, and context filtering.',
-    icon: 'i-heroicons-bolt',
+    icon: resolveIcon('bolt'),
   },
   {
     id: 'mindful',
     name: 'Mindful Productivity',
     description: 'The perfect balance of reflection and execution.',
-    icon: 'i-heroicons-scale',
+    icon: resolveIcon('scale'),
   },
 ]
 
@@ -220,7 +220,7 @@ onMounted(() => {
                   class="p-2.5 rounded-xl shrink-0 transition-colors"
                   :class="selectedProfile === p.id ? 'bg-primary-500 text-white' : 'bg-(--ui-bg-muted) text-(--ui-text-dimmed)'"
                 >
-                  <UIcon :name="p.icon" class="w-6 h-6" />
+                  <AppIcon :name="p.icon" class="w-6 h-6" />
                 </div>
                 <div>
                   <h3 
@@ -238,7 +238,7 @@ onMounted(() => {
 
             <div class="pt-2">
               <div class="flex gap-3 items-start px-1 py-3 mb-2 text-(--ui-text-dimmed)">
-                <UIcon name="i-heroicons-light-bulb" class="w-5 h-5 shrink-0 mt-0.5 text-amber-500" />
+                <AppIcon name="light-bulb" class="w-5 h-5 shrink-0 mt-0.5 text-amber-500" />
                 <p class="text-[13px] font-medium leading-relaxed">
                   You can explore the Settings tab later to further customize your modules and activate Health tracking!
                 </p>
@@ -285,7 +285,7 @@ onMounted(() => {
                   :aria-label="`Select ${t.name} theme`"
                   :aria-pressed="selectedTheme === t.id"
                 >
-                  <UIcon v-if="selectedTheme === t.id" name="i-heroicons-check" class="w-6 h-6 text-white absolute" />
+                  <AppIcon v-if="selectedTheme === t.id" name="check" class="w-6 h-6 text-white absolute" />
                 </div>
                 <span
                   class="text-sm transition-colors"
@@ -301,7 +301,7 @@ onMounted(() => {
               <!-- Habit check item -->
               <div class="flex items-center gap-3 p-3 rounded-xl border bg-(--ui-bg-muted)/50 border-(--ui-border)/50 opacity-80">
                 <div class="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center bg-primary-500/15">
-                  <UIcon name="i-heroicons-beaker" class="w-5 h-5 text-primary-500" />
+                  <AppIcon name="beaker" class="w-5 h-5 text-primary-500" />
                 </div>
                 <div class="flex-1 min-w-0 flex items-center">
                   <div class="min-w-0 pr-2 flex-1 text-left">
@@ -310,14 +310,14 @@ onMounted(() => {
                   </div>
                 </div>
                 <button class="w-7 h-7 rounded-full border-2 flex-shrink-0 flex items-center justify-center bg-primary-500 border-primary-500">
-                  <UIcon name="i-heroicons-check" class="w-3.5 h-3.5 text-white" />
+                  <AppIcon name="check" class="w-3.5 h-3.5 text-white" />
                 </button>
               </div>
 
               <!-- Unchecked metric habit -->
               <div class="flex items-center gap-3 p-3 rounded-xl border bg-(--ui-bg-muted) border-(--ui-border)">
                 <div class="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center bg-primary-500/15">
-                  <UIcon name="i-heroicons-book-open" class="w-5 h-5 text-primary-500" />
+                  <AppIcon name="book-open" class="w-5 h-5 text-primary-500" />
                 </div>
                 <div class="flex-1 min-w-0 flex items-center">
                   <div class="min-w-0 pr-2 flex-1 text-left">

--- a/app/utils/icons.ts
+++ b/app/utils/icons.ts
@@ -1,0 +1,517 @@
+/** Supported icon variants */
+export type IconVariant = 'outline' | 'solid' | 'micro'
+
+/** Definition of a single icon in the registry */
+export interface IconDef {
+  /** Outline (default) icon class */
+  outline: string
+  /** Solid variant icon class */
+  solid?: string
+  /** Micro (16px solid) variant — bolder, less detail */
+  micro?: string
+  /** Human-readable label (for icon picker UI) */
+  label: string
+  /** Category for grouping (in icon picker) */
+  category: string
+}
+
+/**
+ * Standard icon size classes — documented conventions, not enforced.
+ * Use these as a reference when choosing icon sizes in templates.
+ *
+ *   xs  (12px) — badges, inline indicators
+ *   sm  (14px) — toggles, small UI elements
+ *   md  (16px) — buttons, navigation items
+ *   lg  (20px) — main content icons, habit icons
+ *   xl  (32px) — empty states, prominent displays
+ */
+export const ICON_SIZES = {
+  xs: 'w-3 h-3',
+  sm: 'w-3.5 h-3.5',
+  md: 'w-4 h-4',
+  lg: 'w-5 h-5',
+  xl: 'w-8 h-8',
+} as const
+
+/**
+ * Icon registry — single source of truth for all icons used in the app.
+ *
+ * To add a new icon:       add an entry here with outline (required) and solid/micro (optional).
+ * To swap icon libraries:  update the outline/solid/micro strings (e.g., 'i-heroicons-*' → 'i-lucide-*').
+ * To add custom SVG icons: register with a custom prefix (e.g., 'i-custom-*') and configure the icon source.
+ */
+export const iconRegistry: Record<string, IconDef> = {
+  // ── Common / Symbols ────────────────────────────────────────
+  star: {
+    outline: 'i-heroicons-star',
+    solid: 'i-heroicons-star-solid',
+    label: 'Star',
+    category: 'common',
+  },
+  heart: {
+    outline: 'i-heroicons-heart',
+    solid: 'i-heroicons-heart-solid',
+    label: 'Heart',
+    category: 'common',
+  },
+  fire: {
+    outline: 'i-heroicons-fire',
+    solid: 'i-heroicons-fire-solid',
+    label: 'Fire',
+    category: 'common',
+  },
+  bolt: {
+    outline: 'i-heroicons-bolt',
+    solid: 'i-heroicons-bolt-solid',
+    label: 'Bolt',
+    category: 'common',
+  },
+  sparkles: {
+    outline: 'i-heroicons-sparkles',
+    solid: 'i-heroicons-sparkles-solid',
+    label: 'Sparkles',
+    category: 'common',
+  },
+  'light-bulb': {
+    outline: 'i-heroicons-light-bulb',
+    solid: 'i-heroicons-light-bulb-solid',
+    label: 'Light Bulb',
+    category: 'common',
+  },
+  beaker: {
+    outline: 'i-heroicons-beaker',
+    solid: 'i-heroicons-beaker-solid',
+    label: 'Beaker',
+    category: 'common',
+  },
+  'face-smile': {
+    outline: 'i-heroicons-face-smile',
+    solid: 'i-heroicons-face-smile-solid',
+    label: 'Smiley',
+    category: 'common',
+  },
+  scale: {
+    outline: 'i-heroicons-scale',
+    solid: 'i-heroicons-scale-solid',
+    label: 'Scale',
+    category: 'common',
+  },
+
+  // ── Navigation ──────────────────────────────────────────────
+  'arrow-left': {
+    outline: 'i-heroicons-arrow-left',
+    solid: 'i-heroicons-arrow-left-solid',
+    label: 'Arrow Left',
+    category: 'navigation',
+  },
+  'arrow-right': {
+    outline: 'i-heroicons-arrow-right',
+    solid: 'i-heroicons-arrow-right-solid',
+    label: 'Arrow Right',
+    category: 'navigation',
+  },
+  'chevron-down': {
+    outline: 'i-heroicons-chevron-down',
+    solid: 'i-heroicons-chevron-down-solid',
+    label: 'Chevron Down',
+    category: 'navigation',
+  },
+  'chevron-left': {
+    outline: 'i-heroicons-chevron-left',
+    solid: 'i-heroicons-chevron-left-solid',
+    label: 'Chevron Left',
+    category: 'navigation',
+  },
+  'chevron-right': {
+    outline: 'i-heroicons-chevron-right',
+    solid: 'i-heroicons-chevron-right-solid',
+    label: 'Chevron Right',
+    category: 'navigation',
+  },
+  'chevron-up': {
+    outline: 'i-heroicons-chevron-up',
+    solid: 'i-heroicons-chevron-up-solid',
+    label: 'Chevron Up',
+    category: 'navigation',
+  },
+  home: {
+    outline: 'i-heroicons-home',
+    solid: 'i-heroicons-home-solid',
+    label: 'Home',
+    category: 'navigation',
+  },
+  'bars-3': {
+    outline: 'i-heroicons-bars-3',
+    solid: 'i-heroicons-bars-3-solid',
+    label: 'Menu',
+    category: 'navigation',
+  },
+
+  // ── Actions ─────────────────────────────────────────────────
+  plus: {
+    outline: 'i-heroicons-plus',
+    solid: 'i-heroicons-plus-solid',
+    label: 'Plus',
+    category: 'action',
+  },
+  minus: {
+    outline: 'i-heroicons-minus',
+    solid: 'i-heroicons-minus-solid',
+    label: 'Minus',
+    category: 'action',
+  },
+  check: {
+    outline: 'i-heroicons-check',
+    solid: 'i-heroicons-check-solid',
+    label: 'Check',
+    category: 'action',
+  },
+  'x-mark': {
+    outline: 'i-heroicons-x-mark',
+    solid: 'i-heroicons-x-mark-solid',
+    label: 'Close',
+    category: 'action',
+  },
+  trash: {
+    outline: 'i-heroicons-trash',
+    solid: 'i-heroicons-trash-solid',
+    label: 'Trash',
+    category: 'action',
+  },
+  pencil: {
+    outline: 'i-heroicons-pencil',
+    solid: 'i-heroicons-pencil-solid',
+    label: 'Pencil',
+    category: 'action',
+  },
+  'pencil-square': {
+    outline: 'i-heroicons-pencil-square',
+    solid: 'i-heroicons-pencil-square-solid',
+    label: 'Edit',
+    category: 'action',
+  },
+  'arrow-path': {
+    outline: 'i-heroicons-arrow-path',
+    solid: 'i-heroicons-arrow-path-solid',
+    label: 'Refresh',
+    category: 'action',
+  },
+  'magnifying-glass': {
+    outline: 'i-heroicons-magnifying-glass',
+    solid: 'i-heroicons-magnifying-glass-solid',
+    label: 'Search',
+    category: 'action',
+  },
+  'arrows-right-left': {
+    outline: 'i-heroicons-arrows-right-left',
+    solid: 'i-heroicons-arrows-right-left-solid',
+    label: 'Swap',
+    category: 'action',
+  },
+
+  // ── Media ───────────────────────────────────────────────────
+  play: {
+    outline: 'i-heroicons-play',
+    solid: 'i-heroicons-play-solid',
+    micro: 'i-heroicons-play-16-solid',
+    label: 'Play',
+    category: 'media',
+  },
+  pause: {
+    outline: 'i-heroicons-pause',
+    solid: 'i-heroicons-pause-solid',
+    micro: 'i-heroicons-pause-16-solid',
+    label: 'Pause',
+    category: 'media',
+  },
+  stop: {
+    outline: 'i-heroicons-stop',
+    solid: 'i-heroicons-stop-solid',
+    label: 'Stop',
+    category: 'media',
+  },
+  'stop-circle': {
+    outline: 'i-heroicons-stop-circle',
+    solid: 'i-heroicons-stop-circle-solid',
+    label: 'Stop Circle',
+    category: 'media',
+  },
+  microphone: {
+    outline: 'i-heroicons-microphone',
+    solid: 'i-heroicons-microphone-solid',
+    label: 'Microphone',
+    category: 'media',
+  },
+  photo: {
+    outline: 'i-heroicons-photo',
+    solid: 'i-heroicons-photo-solid',
+    label: 'Photo',
+    category: 'media',
+  },
+  camera: {
+    outline: 'i-heroicons-camera',
+    solid: 'i-heroicons-camera-solid',
+    label: 'Camera',
+    category: 'media',
+  },
+
+  // ── Status ──────────────────────────────────────────────────
+  'plus-circle': {
+    outline: 'i-heroicons-plus-circle',
+    solid: 'i-heroicons-plus-circle-solid',
+    label: 'Add',
+    category: 'status',
+  },
+  'check-circle': {
+    outline: 'i-heroicons-check-circle',
+    solid: 'i-heroicons-check-circle-solid',
+    label: 'Done',
+    category: 'status',
+  },
+  'exclamation-circle': {
+    outline: 'i-heroicons-exclamation-circle',
+    solid: 'i-heroicons-exclamation-circle-solid',
+    label: 'Warning',
+    category: 'status',
+  },
+  'exclamation-triangle': {
+    outline: 'i-heroicons-exclamation-triangle',
+    solid: 'i-heroicons-exclamation-triangle-solid',
+    label: 'Alert',
+    category: 'status',
+  },
+  'shield-check': {
+    outline: 'i-heroicons-shield-check',
+    solid: 'i-heroicons-shield-check-solid',
+    label: 'Shield',
+    category: 'status',
+  },
+  'lock-closed': {
+    outline: 'i-heroicons-lock-closed',
+    solid: 'i-heroicons-lock-closed-solid',
+    label: 'Locked',
+    category: 'status',
+  },
+  'lock-open': {
+    outline: 'i-heroicons-lock-open',
+    solid: 'i-heroicons-lock-open-solid',
+    label: 'Unlocked',
+    category: 'status',
+  },
+
+  // ── Content ─────────────────────────────────────────────────
+  'document-text': {
+    outline: 'i-heroicons-document-text',
+    solid: 'i-heroicons-document-text-solid',
+    label: 'Document',
+    category: 'content',
+  },
+  'book-open': {
+    outline: 'i-heroicons-book-open',
+    solid: 'i-heroicons-book-open-solid',
+    label: 'Book',
+    category: 'content',
+  },
+  'clipboard-document-list': {
+    outline: 'i-heroicons-clipboard-document-list',
+    solid: 'i-heroicons-clipboard-document-list-solid',
+    label: 'Clipboard',
+    category: 'content',
+  },
+  tag: {
+    outline: 'i-heroicons-tag',
+    solid: 'i-heroicons-tag-solid',
+    label: 'Tag',
+    category: 'content',
+  },
+  link: {
+    outline: 'i-heroicons-link',
+    solid: 'i-heroicons-link-solid',
+    label: 'Link',
+    category: 'content',
+  },
+  'paper-clip': {
+    outline: 'i-heroicons-paper-clip',
+    solid: 'i-heroicons-paper-clip-solid',
+    label: 'Attachment',
+    category: 'content',
+  },
+
+  // ── Time ────────────────────────────────────────────────────
+  calendar: {
+    outline: 'i-heroicons-calendar',
+    solid: 'i-heroicons-calendar-solid',
+    label: 'Calendar',
+    category: 'time',
+  },
+  'calendar-days': {
+    outline: 'i-heroicons-calendar-days',
+    solid: 'i-heroicons-calendar-days-solid',
+    label: 'Date',
+    category: 'time',
+  },
+  clock: {
+    outline: 'i-heroicons-clock',
+    solid: 'i-heroicons-clock-solid',
+    label: 'Clock',
+    category: 'time',
+  },
+  bell: {
+    outline: 'i-heroicons-bell',
+    solid: 'i-heroicons-bell-solid',
+    label: 'Bell',
+    category: 'time',
+  },
+
+  // ── Data ────────────────────────────────────────────────────
+  'chart-bar': {
+    outline: 'i-heroicons-chart-bar',
+    solid: 'i-heroicons-chart-bar-solid',
+    label: 'Chart',
+    category: 'data',
+  },
+  'table-cells': {
+    outline: 'i-heroicons-table-cells',
+    solid: 'i-heroicons-table-cells-solid',
+    label: 'Table',
+    category: 'data',
+  },
+  'squares-2x2': {
+    outline: 'i-heroicons-squares-2x2',
+    solid: 'i-heroicons-squares-2x2-solid',
+    label: 'Grid',
+    category: 'data',
+  },
+  'list-bullet': {
+    outline: 'i-heroicons-list-bullet',
+    solid: 'i-heroicons-list-bullet-solid',
+    label: 'List',
+    category: 'data',
+  },
+
+  // ── Nature ──────────────────────────────────────────────────
+  sun: {
+    outline: 'i-heroicons-sun',
+    solid: 'i-heroicons-sun-solid',
+    label: 'Sun',
+    category: 'nature',
+  },
+  moon: {
+    outline: 'i-heroicons-moon',
+    solid: 'i-heroicons-moon-solid',
+    label: 'Moon',
+    category: 'nature',
+  },
+
+  // ── System ──────────────────────────────────────────────────
+  'cog-6-tooth': {
+    outline: 'i-heroicons-cog-6-tooth',
+    solid: 'i-heroicons-cog-6-tooth-solid',
+    label: 'Settings',
+    category: 'system',
+  },
+  'circle-stack': {
+    outline: 'i-heroicons-circle-stack',
+    solid: 'i-heroicons-circle-stack-solid',
+    label: 'Database',
+    category: 'system',
+  },
+  inbox: {
+    outline: 'i-heroicons-inbox',
+    solid: 'i-heroicons-inbox-solid',
+    label: 'Inbox',
+    category: 'system',
+  },
+  'archive-box': {
+    outline: 'i-heroicons-archive-box',
+    solid: 'i-heroicons-archive-box-solid',
+    label: 'Archive',
+    category: 'system',
+  },
+  swatch: {
+    outline: 'i-heroicons-swatch',
+    solid: 'i-heroicons-swatch-solid',
+    label: 'Theme',
+    category: 'system',
+  },
+  'adjustments-horizontal': {
+    outline: 'i-heroicons-adjustments-horizontal',
+    solid: 'i-heroicons-adjustments-horizontal-solid',
+    label: 'Adjust',
+    category: 'system',
+  },
+  'ellipsis-horizontal-circle': {
+    outline: 'i-heroicons-ellipsis-horizontal-circle',
+    solid: 'i-heroicons-ellipsis-horizontal-circle-solid',
+    label: 'More',
+    category: 'system',
+  },
+  'battery-100': { outline: 'i-heroicons-battery-100', label: 'Battery', category: 'system' },
+  'user-circle': {
+    outline: 'i-heroicons-user-circle',
+    solid: 'i-heroicons-user-circle-solid',
+    label: 'User',
+    category: 'system',
+  },
+
+  // ── Transfer ────────────────────────────────────────────────
+  'arrow-down-tray': {
+    outline: 'i-heroicons-arrow-down-tray',
+    solid: 'i-heroicons-arrow-down-tray-solid',
+    label: 'Download',
+    category: 'transfer',
+  },
+  'arrow-up-tray': {
+    outline: 'i-heroicons-arrow-up-tray',
+    solid: 'i-heroicons-arrow-up-tray-solid',
+    label: 'Upload',
+    category: 'transfer',
+  },
+  'arrow-up-on-square': {
+    outline: 'i-heroicons-arrow-up-on-square',
+    solid: 'i-heroicons-arrow-up-on-square-solid',
+    label: 'Share',
+    category: 'transfer',
+  },
+  'arrow-top-right-on-square': {
+    outline: 'i-heroicons-arrow-top-right-on-square',
+    solid: 'i-heroicons-arrow-top-right-on-square-solid',
+    label: 'External',
+    category: 'transfer',
+  },
+}
+
+/**
+ * Resolve an icon name to its underlying class string.
+ *
+ * Accepts either:
+ *  - A registry key (e.g., 'star') → looks up in iconRegistry
+ *  - A raw icon class (e.g., 'i-heroicons-star') → returned as-is
+ *
+ * Falls back to outline when the requested variant is unavailable.
+ */
+export function resolveIcon(name: string, variant: IconVariant = 'outline'): string {
+  // Pass through raw icon classes (from DB or other icon libraries)
+  if (name.startsWith('i-')) return name
+
+  const entry = iconRegistry[name]
+  if (!entry) return name
+
+  if (variant === 'solid' && entry.solid) return entry.solid
+  if (variant === 'micro' && entry.micro) return entry.micro
+  return entry.outline
+}
+
+/**
+ * Get all icons grouped by category — useful for icon picker UIs.
+ * Each entry includes the registry key as `name`.
+ */
+export function iconsByCategory(): Record<string, Array<{ name: string } & IconDef>> {
+  const grouped: Record<string, Array<{ name: string } & IconDef>> = {}
+  for (const [name, def] of Object.entries(iconRegistry)) {
+    const cat = def.category
+    if (!grouped[cat]) grouped[cat] = []
+    grouped[cat].push({ name, ...def })
+  }
+  return grouped
+}

--- a/app/utils/navigation.ts
+++ b/app/utils/navigation.ts
@@ -1,3 +1,5 @@
+import { resolveIcon } from '~/utils/icons'
+
 export interface NavItem {
   to: string
   icon: string
@@ -10,11 +12,11 @@ export interface NavItem {
 }
 
 export const ALL_NAV_ITEMS: NavItem[] = [
-  { to: '/', icon: 'i-heroicons-home', label: 'Today', today: true },
-  { to: '/habits', icon: 'i-heroicons-list-bullet', label: 'Habits' },
-  { to: '/checkin', icon: 'i-heroicons-pencil-square', label: 'Check-in', journalling: true },
-  { to: '/todos', icon: 'i-heroicons-check-circle', label: 'TODOs', todos: true },
-  { to: '/bored', icon: 'i-heroicons-face-smile', label: 'Bored', bored: true },
-  { to: '/health', icon: 'i-heroicons-heart', label: 'Health', health: true },
-  { to: '/jots', icon: 'i-heroicons-document-text', label: 'Jots', journalling: true },
+  { to: '/', icon: resolveIcon('home'), label: 'Today', today: true },
+  { to: '/habits', icon: resolveIcon('list-bullet'), label: 'Habits' },
+  { to: '/checkin', icon: resolveIcon('pencil-square'), label: 'Check-in', journalling: true },
+  { to: '/todos', icon: resolveIcon('check-circle'), label: 'TODOs', todos: true },
+  { to: '/bored', icon: resolveIcon('face-smile'), label: 'Bored', bored: true },
+  { to: '/health', icon: resolveIcon('heart'), label: 'Health', health: true },
+  { to: '/jots', icon: resolveIcon('document-text'), label: 'Jots', journalling: true },
 ]

--- a/tests/unit/BackNav.test.ts
+++ b/tests/unit/BackNav.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
+
 import BackNav from '~/components/BackNav.vue'
+
+const mockResolveIcon = (name: string) => `i-heroicons-${name}`
 
 function makeRouter() {
   return createRouter({
@@ -16,6 +19,7 @@ describe('BackNav', () => {
       props: { to: '/habits', label: 'Habits' },
       global: {
         plugins: [makeRouter()],
+        mocks: { resolveIcon: mockResolveIcon },
         stubs: { UButton: { template: '<a :href="to"><slot /></a>', props: ['to', 'icon'] } },
       },
     })
@@ -27,6 +31,7 @@ describe('BackNav', () => {
       props: { to: '/checkin', label: 'Check-ins' },
       global: {
         plugins: [makeRouter()],
+        mocks: { resolveIcon: mockResolveIcon },
         stubs: { UButton: { template: '<a :href="to"><slot /></a>', props: ['to', 'icon'] } },
       },
     })
@@ -38,6 +43,7 @@ describe('BackNav', () => {
       props: { to: '/habits', label: 'Habits' },
       global: {
         plugins: [makeRouter()],
+        mocks: { resolveIcon: mockResolveIcon },
         stubs: {
           UButton: {
             name: 'UButton',

--- a/tests/unit/CollapsibleSection.test.ts
+++ b/tests/unit/CollapsibleSection.test.ts
@@ -6,7 +6,7 @@ describe('CollapsibleSection', () => {
   it('renders the toggle button with the closed label', () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Add annotations' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.find('button').text()).toContain('Add annotations')
   })
@@ -15,7 +15,7 @@ describe('CollapsibleSection', () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Add annotations' },
       slots: { default: '<p class="slot-content">inner</p>' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.find('.slot-content').exists()).toBe(false)
   })
@@ -24,7 +24,7 @@ describe('CollapsibleSection', () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Hide annotations', defaultOpen: true },
       slots: { default: '<p class="slot-content">inner</p>' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.find('.slot-content').exists()).toBe(true)
   })
@@ -33,7 +33,7 @@ describe('CollapsibleSection', () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Add annotations' },
       slots: { default: '<p class="slot-content">inner</p>' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button').trigger('click')
     expect(wrapper.find('.slot-content').exists()).toBe(true)
@@ -43,7 +43,7 @@ describe('CollapsibleSection', () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Add annotations' },
       slots: { default: '<p class="slot-content">inner</p>' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button').trigger('click')
     await wrapper.find('button').trigger('click')
@@ -53,7 +53,7 @@ describe('CollapsibleSection', () => {
   it('shows openLabel when provided and expanded', async () => {
     const wrapper = mount(CollapsibleSection, {
       props: { label: 'Add annotations', openLabel: 'Hide annotations' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button').trigger('click')
     expect(wrapper.find('button').text()).toContain('Hide annotations')

--- a/tests/unit/ConfirmDialog.test.ts
+++ b/tests/unit/ConfirmDialog.test.ts
@@ -20,7 +20,7 @@ describe('ConfirmDialog', () => {
   it('renders nothing when open is false', () => {
     const wrapper = mount(ConfirmDialog, {
       props: { ...baseProps, open: false },
-      global: { stubs: { UModal: UModalStub, UIcon: true, UButton: true } },
+      global: { stubs: { UModal: UModalStub, AppIcon: true, UButton: true } },
     })
     expect(wrapper.text()).toBe('')
   })
@@ -28,7 +28,7 @@ describe('ConfirmDialog', () => {
   it('renders title and message when open', () => {
     const wrapper = mount(ConfirmDialog, {
       props: baseProps,
-      global: { stubs: { UModal: UModalStub, UIcon: true, UButton: true } },
+      global: { stubs: { UModal: UModalStub, AppIcon: true, UButton: true } },
     })
     expect(wrapper.text()).toContain('Delete item?')
     expect(wrapper.text()).toContain('This cannot be undone.')
@@ -40,7 +40,7 @@ describe('ConfirmDialog', () => {
       global: {
         stubs: {
           UModal: UModalStub,
-          UIcon: true,
+          AppIcon: true,
           UButton: {
             name: 'UButton',
             props: ['color'],
@@ -63,7 +63,7 @@ describe('ConfirmDialog', () => {
       global: {
         stubs: {
           UModal: UModalStub,
-          UIcon: true,
+          AppIcon: true,
           UButton: {
             name: 'UButton',
             props: ['color'],
@@ -86,7 +86,7 @@ describe('ConfirmDialog', () => {
       global: {
         stubs: {
           UModal: UModalStub,
-          UIcon: true,
+          AppIcon: true,
           UButton: {
             name: 'UButton',
             template: '<button @click="$emit(\'click\')"><slot /></button>',

--- a/tests/unit/EmptyState.test.ts
+++ b/tests/unit/EmptyState.test.ts
@@ -6,7 +6,7 @@ describe('EmptyState', () => {
   it('renders the title', () => {
     const wrapper = mount(EmptyState, {
       props: { icon: 'i-heroicons-star', title: 'Nothing here' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.text()).toContain('Nothing here')
   })
@@ -14,7 +14,7 @@ describe('EmptyState', () => {
   it('renders description when provided', () => {
     const wrapper = mount(EmptyState, {
       props: { icon: 'i-heroicons-star', title: 'Nothing here', description: 'Add one to get started.' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.text()).toContain('Add one to get started.')
   })
@@ -22,7 +22,7 @@ describe('EmptyState', () => {
   it('does not render description element when omitted', () => {
     const wrapper = mount(EmptyState, {
       props: { icon: 'i-heroicons-star', title: 'Nothing here' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     // The description paragraph is uniquely identified by text-sm; the title
     // paragraph uses font-semibold. Checking the specific element is more
@@ -30,12 +30,12 @@ describe('EmptyState', () => {
     expect(wrapper.find('p.text-sm').exists()).toBe(false)
   })
 
-  it('passes the icon name to UIcon', () => {
+  it('passes the icon name to AppIcon', () => {
     const wrapper = mount(EmptyState, {
       props: { icon: 'i-heroicons-fire', title: 'x' },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
-    const icon = wrapper.findComponent({ name: 'UIcon' })
+    const icon = wrapper.findComponent({ name: 'AppIcon' })
     expect(icon.attributes('name')).toBe('i-heroicons-fire')
   })
 })

--- a/tests/unit/JotsRing.test.ts
+++ b/tests/unit/JotsRing.test.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue'
 
 // Stub Nuxt auto-imports used by JotsRing
 vi.stubGlobal('useAppSettings', () => ({ settings: ref({ reduceMotion: false }) }))
+vi.stubGlobal('resolveIcon', (name: string) => `i-heroicons-${name}`)
 
 import JotsRing from '~/components/JotsRing.vue'
 
@@ -20,14 +21,14 @@ describe('JotsRing', () => {
 
   it('renders three ring-node buttons in default mode', () => {
     const wrapper = mount(JotsRing, {
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.findAll('button.jots-ring-node')).toHaveLength(3)
   })
 
   it('emits select with "text" when the text node is clicked', async () => {
     const wrapper = mount(JotsRing, {
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button[data-jot-type="text"]').trigger('click')
     expect(wrapper.emitted('select')).toBeTruthy()
@@ -36,7 +37,7 @@ describe('JotsRing', () => {
 
   it('emits select with "voice" when the voice node is clicked', async () => {
     const wrapper = mount(JotsRing, {
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button[data-jot-type="voice"]').trigger('click')
     expect(wrapper.emitted('select')![0]).toEqual(['voice'])
@@ -44,7 +45,7 @@ describe('JotsRing', () => {
 
   it('emits select with "image" when the image node is clicked', async () => {
     const wrapper = mount(JotsRing, {
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button[data-jot-type="image"]').trigger('click')
     expect(wrapper.emitted('select')![0]).toEqual(['image'])
@@ -53,7 +54,7 @@ describe('JotsRing', () => {
   it('renders compact mode with three buttons', () => {
     const wrapper = mount(JotsRing, {
       props: { compact: true },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     expect(wrapper.findAll('button')).toHaveLength(3)
   })
@@ -61,7 +62,7 @@ describe('JotsRing', () => {
   it('emits select from compact mode', async () => {
     const wrapper = mount(JotsRing, {
       props: { compact: true },
-      global: { stubs: { UIcon: true } },
+      global: { stubs: { AppIcon: true } },
     })
     await wrapper.find('button[data-jot-type="text"]').trigger('click')
     expect(wrapper.emitted('select')![0]).toEqual(['text'])

--- a/tests/unit/icons.test.ts
+++ b/tests/unit/icons.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { ICON_SIZES, iconRegistry, iconsByCategory, resolveIcon } from '~/utils/icons'
+
+describe('resolveIcon', () => {
+  it('resolves a registry name to its outline class', () => {
+    expect(resolveIcon('star')).toBe('i-heroicons-star')
+    expect(resolveIcon('plus')).toBe('i-heroicons-plus')
+    expect(resolveIcon('check')).toBe('i-heroicons-check')
+  })
+
+  it('resolves a registry name to its solid class', () => {
+    expect(resolveIcon('star', 'solid')).toBe('i-heroicons-star-solid')
+    expect(resolveIcon('heart', 'solid')).toBe('i-heroicons-heart-solid')
+  })
+
+  it('resolves micro variant for play/pause', () => {
+    expect(resolveIcon('play', 'micro')).toBe('i-heroicons-play-16-solid')
+    expect(resolveIcon('pause', 'micro')).toBe('i-heroicons-pause-16-solid')
+  })
+
+  it('falls back to outline when requested variant is unavailable', () => {
+    expect(resolveIcon('battery-100', 'solid')).toBe('i-heroicons-battery-100')
+    expect(resolveIcon('star', 'micro')).toBe('i-heroicons-star')
+  })
+
+  it('passes through raw i-* strings unchanged', () => {
+    expect(resolveIcon('i-heroicons-star')).toBe('i-heroicons-star')
+    expect(resolveIcon('i-lucide-star')).toBe('i-lucide-star')
+    expect(resolveIcon('i-custom-logo')).toBe('i-custom-logo')
+  })
+
+  it('passes through raw strings unchanged regardless of variant', () => {
+    expect(resolveIcon('i-heroicons-star', 'solid')).toBe('i-heroicons-star')
+  })
+
+  it('returns name unchanged for unknown non-prefixed names', () => {
+    expect(resolveIcon('unknown-icon-xyz')).toBe('unknown-icon-xyz')
+  })
+})
+
+describe('iconsByCategory', () => {
+  it('groups all icons by category', () => {
+    const grouped = iconsByCategory()
+    const totalIcons = Object.values(grouped).flat().length
+    expect(totalIcons).toBe(Object.keys(iconRegistry).length)
+  })
+
+  it('each entry includes name, outline, and label', () => {
+    const grouped = iconsByCategory()
+    for (const entries of Object.values(grouped)) {
+      for (const entry of entries) {
+        expect(entry.name).toBeTruthy()
+        expect(entry.outline).toMatch(/^i-/)
+        expect(entry.label).toBeTruthy()
+      }
+    }
+  })
+
+  it('has expected categories', () => {
+    const grouped = iconsByCategory()
+    const categories = Object.keys(grouped)
+    expect(categories).toContain('common')
+    expect(categories).toContain('navigation')
+    expect(categories).toContain('action')
+    expect(categories).toContain('media')
+  })
+})
+
+describe('iconRegistry', () => {
+  it('contains all expected icons', () => {
+    const expected = [
+      'star', 'heart', 'fire', 'bolt', 'sparkles',
+      'plus', 'minus', 'check', 'trash', 'pencil',
+      'play', 'pause', 'stop', 'microphone',
+      'home', 'arrow-left', 'chevron-down',
+      'calendar', 'clock', 'bell',
+      'sun', 'moon',
+    ]
+    for (const name of expected) {
+      expect(iconRegistry[name], `missing icon: ${name}`).toBeDefined()
+    }
+  })
+
+  it('all entries have valid outline values starting with i-', () => {
+    for (const [name, def] of Object.entries(iconRegistry)) {
+      expect(def.outline, `${name} outline`).toMatch(/^i-/)
+    }
+  })
+
+  it('all solid values start with i- when present', () => {
+    for (const [name, def] of Object.entries(iconRegistry)) {
+      if (def.solid) {
+        expect(def.solid, `${name} solid`).toMatch(/^i-/)
+      }
+    }
+  })
+
+  it('all micro values start with i- when present', () => {
+    for (const [name, def] of Object.entries(iconRegistry)) {
+      if (def.micro) {
+        expect(def.micro, `${name} micro`).toMatch(/^i-/)
+      }
+    }
+  })
+
+  it('all entries have a label and category', () => {
+    for (const [name, def] of Object.entries(iconRegistry)) {
+      expect(def.label, `${name} label`).toBeTruthy()
+      expect(def.category, `${name} category`).toBeTruthy()
+    }
+  })
+})
+
+describe('ICON_SIZES', () => {
+  it('documents standard size conventions', () => {
+    expect(ICON_SIZES).toEqual({
+      xs: 'w-3 h-3',
+      sm: 'w-3.5 h-3.5',
+      md: 'w-4 h-4',
+      lg: 'w-5 h-5',
+      xl: 'w-8 h-8',
+    })
+  })
+})

--- a/tests/unit/notifications-toast.test.ts
+++ b/tests/unit/notifications-toast.test.ts
@@ -19,6 +19,7 @@ vi.mock('@capacitor/core', () => ({
   },
 }))
 
+import { resolveIcon } from '~/utils/icons'
 import { useNotifications } from '~/composables/useNotifications'
 
 // ── Shared stubs ─────────────────────────────────────────────────────────────
@@ -38,6 +39,7 @@ beforeAll(() => {
   g['useToast'] = () => ({ add: mockToastAdd })
   g['useDatabase'] = () => dbStub
   g['useRouter'] = () => ({ push: vi.fn() })
+  g['resolveIcon'] = resolveIcon
 })
 
 beforeEach(() => {

--- a/tests/unit/ux-feedback.test.ts
+++ b/tests/unit/ux-feedback.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { shallowMount, flushPromises } from '@vue/test-utils'
+import { shallowMount, flushPromises, config } from '@vue/test-utils'
 import { ref } from 'vue'
 
 vi.mock('@capacitor/core', () => ({
@@ -69,6 +69,7 @@ g['useTagInput'] = () => ({
   onTagKeydown: vi.fn(),
 })
 g['useLongPress'] = () => ({ start: vi.fn(), cancel: vi.fn(), activated: ref(false) })
+g['resolveIcon'] = (name: string) => `i-heroicons-${name}`
 
 // Stub localStorage for settings/data.vue which calls localStorage.removeItem
 vi.stubGlobal('localStorage', {
@@ -89,6 +90,9 @@ vi.stubGlobal('indexedDB', {
   }),
   open: vi.fn(() => ({ onsuccess: null, onerror: null, onupgradeneeded: null })),
 })
+
+// Make resolveIcon available in Vue template context for all shallowMount calls
+config.global.mocks.resolveIcon = (name: string) => `i-heroicons-${name}`
 
 // ── Shared DB stub ────────────────────────────────────────────────────────────
 const mockDb = {


### PR DESCRIPTION
## Summary

- Introduces `app/utils/icons.ts` as the **single source of truth** for all ~70 icons used across the app, with `resolveIcon()` for name resolution, `iconsByCategory()` for picker UIs, and `ICON_SIZES` documenting size conventions
- Adds `AppIcon.vue` wrapper component with `name`, `variant` (outline/solid/micro), and `color` props — replaces direct `UIcon` usage everywhere
- Migrates **all 36 Vue files**, layout, navigation, and composables from raw `i-heroicons-*` strings to semantic registry names

### Why this matters
- **Swap icon libraries**: change `i-heroicons-*` → `i-lucide-*` in one file instead of 40+
- **Custom icons**: register with any prefix (e.g., `i-custom-*`)
- **Variant control**: outline, solid, and micro (16px) variants via a single prop
- **Icon picker ready**: `iconsByCategory()` provides grouped icons for future picker components
- **DB-compatible**: `resolveIcon()` passes through raw `i-*` strings, so DB-stored icons work unchanged

## Test plan

- [x] All 444 unit tests pass (16 new icon registry tests added)
- [x] TypeScript typecheck clean
- [x] Biome lint/format clean
- [ ] Visual smoke test: verify icons render correctly across all pages
- [ ] Verify DB-stored icons (habits, bored categories) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)